### PR TITLE
fix: #23 — usar safe_fromstring em _salvar_log_xml (XXE)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.2.54
+- fix: #23 — usar safe_fromstring em _salvar_log_xml (XXE)
+
 ## 0.2.53
 - fix: resolver issues #16-#19 — XXE em emissao/manifestacao/inutilizacao, timezone BRT compartilhado, timeout SEFAZ via monkey-patch, dedup cmd_consultar_nsu
 

--- a/nfe_sync/commands/__init__.py
+++ b/nfe_sync/commands/__init__.py
@@ -3,13 +3,11 @@ import os
 import sys
 from abc import ABC, abstractmethod
 
-from pynfe.utils import etree
-
 from ..config import carregar_empresas
 from ..state import carregar_estado, salvar_estado
 from ..log import salvar_resposta_sefaz
 from ..exceptions import NfeConfigError, NfeValidationError
-from ..xml_utils import safe_parse
+from ..xml_utils import safe_parse, safe_fromstring
 
 # Issue #4: caminhos de config e estado configuráveis via variáveis de ambiente
 CONFIG_FILE = os.environ.get("NFE_SYNC_CONFIG", "nfe-sync.conf.ini")
@@ -57,7 +55,7 @@ def _salvar_xml(cnpj: str, nome: str, xml: str) -> str:
 
 def _salvar_log_xml(xml_str: str, tipo: str, ref: str) -> str:
     """Salva resposta SEFAZ em log/. Wrapper sobre log.salvar_resposta_sefaz()."""
-    xml_el = etree.fromstring(xml_str.encode())
+    xml_el = safe_fromstring(xml_str.encode())
     return salvar_resposta_sefaz(xml_el, tipo, ref)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nfe-sync"
-version = "0.2.53"
+version = "0.2.54"
 requires-python = ">=3.12"
 dependencies = ["pynfe>=0.6.5", "python-dotenv", "pydantic>=2.0", "requests", "signxml"]
 

--- a/tests/test_commands_init.py
+++ b/tests/test_commands_init.py
@@ -1,0 +1,31 @@
+"""Testes para commands/__init__.py — Issue #23: XXE em _salvar_log_xml."""
+from unittest.mock import patch, MagicMock
+
+import nfe_sync.commands as cmds_mod
+
+
+class TestSalvarLogXmlSeguro:
+    """Issue #23: _salvar_log_xml deve usar safe_fromstring, não etree.fromstring."""
+
+    XML_SIMPLES = '<?xml version="1.0"?><retConsSitNFe><cStat>100</cStat></retConsSitNFe>'
+
+    def test_usa_safe_fromstring_nao_etree(self):
+        """Garantia: safe_fromstring é chamado (sem vulnerabilidade XXE)."""
+        with patch.object(cmds_mod, "safe_fromstring") as mock_safe, \
+             patch("nfe_sync.commands.salvar_resposta_sefaz", return_value="log/x.xml") as mock_salvar:
+            mock_safe.return_value = MagicMock()
+            cmds_mod._salvar_log_xml(self.XML_SIMPLES, "consulta", "chave123")
+
+        mock_safe.assert_called_once()
+        args = mock_safe.call_args[0]
+        assert args[0] == self.XML_SIMPLES.encode()
+
+    def test_nao_usa_etree_fromstring(self):
+        """Garantia: etree.fromstring NÃO é chamado (removido do módulo)."""
+        from pynfe.utils import etree
+        with patch.object(etree, "fromstring") as mock_etree, \
+             patch.object(cmds_mod, "safe_fromstring", return_value=MagicMock()), \
+             patch("nfe_sync.commands.salvar_resposta_sefaz", return_value="log/x.xml"):
+            cmds_mod._salvar_log_xml(self.XML_SIMPLES, "consulta", "chave123")
+
+        mock_etree.assert_not_called()


### PR DESCRIPTION
## Problema

`_salvar_log_xml` em `commands/__init__.py:60` usava `etree.fromstring()` que é vulnerável a ataques XXE (XML External Entity), permitindo leitura de arquivos locais via entidade XML maliciosa.

## Solução

- Remove import de `etree` do módulo
- Importa `safe_fromstring` de `xml_utils` (já existente no projeto desde issue #9)
- Substitui `etree.fromstring()` por `safe_fromstring()` que desabilita processamento de entidades externas

## Teste

`tests/test_commands_init.py` — `TestSalvarLogXmlSeguro`:
- Verifica que `safe_fromstring` é chamado com o XML codificado
- Verifica que `etree.fromstring` NÃO é chamado

## Verificação

```
pytest tests/test_commands_init.py -v  # 2 passed
pytest tests/ -v                       # 113 passed
```

Closes #23