### PR TITLE
fix: #21 — validar chave de acesso localmente antes de enviar à SEFAZ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.2.55
+- fix: #21 — validar chave de acesso localmente antes de enviar a SEFAZ
+
 ## 0.2.54
 - fix: #23 — usar safe_fromstring em _salvar_log_xml (XXE)
 

--- a/nfe_sync/consulta.py
+++ b/nfe_sync/consulta.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta
 from .models import EmpresaConfig, validar_cnpj_sefaz
 from .state import get_ultimo_nsu, set_ultimo_nsu, get_cooldown, set_cooldown, salvar_estado
 from .xml_utils import to_xml_string, extract_status_motivo, criar_comunicacao, safe_fromstring, agora_brt
+from .exceptions import NfeValidationError
 
 
 COOLDOWN_MINUTOS = 61
@@ -136,6 +137,10 @@ def _processar_docs(xml_resp) -> list[dict]:
 
 
 def consultar(empresa: EmpresaConfig, chave: str) -> dict:
+    if len(chave) != 44 or not chave.isdigit():
+        raise NfeValidationError(
+            f"[{empresa.nome}] Chave de acesso deve ter 44 digitos numericos, recebeu: '{chave}'"
+        )
     validar_cnpj_sefaz(empresa.emitente.cnpj, empresa.nome)
     uf = _uf_da_chave(chave) or empresa.uf
     con = criar_comunicacao(empresa, uf=uf)
@@ -157,6 +162,10 @@ def consultar(empresa: EmpresaConfig, chave: str) -> dict:
 
 def consultar_dfe_chave(empresa: EmpresaConfig, chave: str) -> dict:
     """Baixa o documento DFe (procNFe) diretamente pela chave de acesso."""
+    if len(chave) != 44 or not chave.isdigit():
+        raise NfeValidationError(
+            f"[{empresa.nome}] Chave de acesso deve ter 44 digitos numericos, recebeu: '{chave}'"
+        )
     validar_cnpj_sefaz(empresa.emitente.cnpj, empresa.nome)
     cnpj = empresa.emitente.cnpj
     uf = _uf_da_chave(chave) or empresa.uf

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nfe-sync"
-version = "0.2.54"
+version = "0.2.55"
 requires-python = ">=3.12"
 dependencies = ["pynfe>=0.6.5", "python-dotenv", "pydantic>=2.0", "requests", "signxml"]
 


### PR DESCRIPTION
## Problema

`consultar()` e `consultar_dfe_chave()` em `consulta.py` enviavam qualquer string para a SEFAZ sem validação prévia, gerando erros obscuros (SSL, certificado, HTTP) ao receber chaves inválidas.

## Solução

Adiciona validação no início de ambas as funções:
```python
if len(chave) != 44 or not chave.isdigit():
    raise NfeValidationError(...)
```

Mesmo padrão já usado em `manifestacao.py` (linhas 36-39). A exceção é capturada pelo `cli.py` e exibe mensagem clara, saindo com código 1.

## Testes

`tests/test_consulta.py` — `TestValidarChave`:
- Chave curta → `NfeValidationError`
- Chave com letras → `NfeValidationError`
- Chave vazia → `NfeValidationError`
- Chave válida (44 dígitos) → passa validação e chega à chamada SEFAZ (mockada)
- `consultar_dfe_chave` com chave inválida → `NfeValidationError`

## Verificação

```
pytest tests/test_consulta.py::TestValidarChave -v  # 6 passed
pytest tests/ -v                                     # 117 passed
```

Closes #21