### PR TITLE
refactor: #25 — dataclasses de retorno

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.2.59
+- refactor: #25 — dataclasses de retorno (ResultadoConsulta, ResultadoDistribuicao, etc.)
+
+## 0.2.58
+- refactor: #25 #26 #27 — dataclasses de retorno, DocumentoStorage e chamar_sefaz
+
 ## 0.2.57
 - fix: #20 — aceitar --producao/--homologacao antes ou depois do subcomando
 

--- a/nfe_sync/commands/emissao.py
+++ b/nfe_sync/commands/emissao.py
@@ -66,27 +66,27 @@ def cmd_emitir(args):
     from ..emissao import emitir
     resultado = emitir(empresa, serie, numero_nf, dados)
 
-    if resultado.get("sucesso"):
-        _salvar_log_xml(resultado["xml"], "emissao", cnpj)
+    if resultado.sucesso:
+        _salvar_log_xml(resultado.xml, "emissao", cnpj)
         os.makedirs("xml", exist_ok=True)
-        arquivo = f"xml/{resultado['chave']}.xml"
+        arquivo = f"xml/{resultado.chave}.xml"
         with open(arquivo, "w") as f:
-            f.write(resultado["xml"])
+            f.write(resultado.xml)
 
-        print(f"Status: {resultado['status']}")
-        print(f"Motivo: {resultado['motivo']}")
-        print(f"Protocolo: {resultado['protocolo']}")
-        print(f"Chave: {resultado['chave']}")
+        print(f"Status: {resultado.status}")
+        print(f"Motivo: {resultado.motivo}")
+        print(f"Protocolo: {resultado.protocolo}")
+        print(f"Chave: {resultado.chave}")
         print(f"XML salvo em: {arquivo}")
 
         set_ultimo_numero_nf(estado, cnpj, serie, numero_nf)
         salvar_estado(STATE_FILE, estado)
         print(f"Numero NF {numero_nf} serie {serie} salvo em {STATE_FILE}")
     else:
-        if resultado.get("xml_resposta"):
-            _salvar_log_xml(resultado["xml_resposta"], "emissao-erro", cnpj)
+        if resultado.xml_resposta:
+            _salvar_log_xml(resultado.xml_resposta, "emissao-erro", cnpj)
         print("ERRO na emissao:")
-        for erro in resultado.get("erros", []):
+        for erro in resultado.erros:
             print(f"  cStat={erro['status']}  {erro['motivo']}")
         sys.exit(1)
 

--- a/nfe_sync/commands/inutilizacao.py
+++ b/nfe_sync/commands/inutilizacao.py
@@ -18,17 +18,17 @@ def cmd_inutilizar(args):
     from ..inutilizacao import inutilizar
     resultado = inutilizar(empresa, args.serie, args.inicio, args.fim, args.justificativa)
 
-    _salvar_log_xml(resultado["xml_resposta"], "inutilizacao", f"{cnpj}-serie{args.serie}-{args.inicio}-{args.fim}")
+    _salvar_log_xml(resultado.xml_resposta, "inutilizacao", f"{cnpj}-serie{args.serie}-{args.inicio}-{args.fim}")
     os.makedirs("xml/inutilizacao", exist_ok=True)
     arquivo = f"xml/inutilizacao/inut-serie{args.serie}-{args.inicio}-{args.fim}.xml"
     with open(arquivo, "w") as f:
-        f.write(resultado["xml"])
+        f.write(resultado.xml)
 
     print("=== RESULTADO ===")
-    for r in resultado["resultados"]:
+    for r in resultado.resultados:
         print(f"  cStat={r['status']}  {r['motivo']}")
-    if resultado["protocolo"]:
-        print(f"  Protocolo: {resultado['protocolo']}")
+    if resultado.protocolo:
+        print(f"  Protocolo: {resultado.protocolo}")
     print(f"  Resposta salva em: {arquivo}")
 
 

--- a/nfe_sync/commands/manifestacao.py
+++ b/nfe_sync/commands/manifestacao.py
@@ -18,14 +18,14 @@ def cmd_manifestar(args):
     from ..manifestacao import manifestar
     resultado = manifestar(empresa, args.operacao, args.chave, args.justificativa)
 
-    _salvar_log_xml(resultado["xml_resposta"], "manifestacao", f"{cnpj}-{args.operacao}")
-    arquivo = _salvar_xml(cnpj, f"{args.chave}-evento-{args.operacao}.xml", resultado["xml"])
+    _salvar_log_xml(resultado.xml_resposta, "manifestacao", f"{cnpj}-{args.operacao}")
+    arquivo = _salvar_xml(cnpj, f"{args.chave}-evento-{args.operacao}.xml", resultado.xml)
 
     print("=== RESULTADO ===")
-    for r in resultado["resultados"]:
+    for r in resultado.resultados:
         print(f"  cStat={r['status']}  {r['motivo']}")
-    if resultado["protocolo"]:
-        print(f"  Protocolo: {resultado['protocolo']}")
+    if resultado.protocolo:
+        print(f"  Protocolo: {resultado.protocolo}")
     print(f"  Resposta salva em: {arquivo}")
 
 

--- a/nfe_sync/inutilizacao.py
+++ b/nfe_sync/inutilizacao.py
@@ -1,6 +1,7 @@
 from .models import EmpresaConfig, validar_cnpj_sefaz
 from .exceptions import NfeValidationError
 from .xml_utils import to_xml_string, extract_status_motivo, criar_comunicacao, safe_fromstring
+from .results import ResultadoInutilizacao
 
 
 NS = {"ns": "http://www.portalfiscal.inf.br/nfe"}
@@ -43,9 +44,9 @@ def inutilizar(
     resultados = extract_status_motivo(xml_resp, NS)
     protocolos = xml_resp.xpath("//ns:nProt", namespaces=NS)
 
-    return {
-        "resultados": resultados,
-        "protocolo": protocolos[0].text if protocolos else None,
-        "xml": xml_resp_str,
-        "xml_resposta": xml_resp_str,
-    }
+    return ResultadoInutilizacao(
+        resultados=resultados,
+        protocolo=protocolos[0].text if protocolos else None,
+        xml=xml_resp_str,
+        xml_resposta=xml_resp_str,
+    )

--- a/nfe_sync/manifestacao.py
+++ b/nfe_sync/manifestacao.py
@@ -6,6 +6,7 @@ from pynfe.processamento.assinatura import AssinaturaA1
 from .models import EmpresaConfig, validar_cnpj_sefaz
 from .exceptions import NfeValidationError
 from .xml_utils import to_xml_string, extract_status_motivo, criar_comunicacao, safe_fromstring, agora_brt
+from .results import ResultadoManifestacao
 
 
 NS = {"ns": "http://www.portalfiscal.inf.br/nfe"}
@@ -23,7 +24,7 @@ def manifestar(
     operacao: str,
     chave: str,
     justificativa: str = "",
-) -> dict:
+) -> ResultadoManifestacao:
     if operacao not in OPERACOES:
         raise NfeValidationError(
             f"[{empresa.nome}] Operacao '{operacao}' invalida. "
@@ -74,10 +75,9 @@ def manifestar(
     resultados = extract_status_motivo(xml_resp, NS)
     protocolos = xml_resp.xpath("//ns:nProt", namespaces=NS)
 
-    return {
-        "operacao": operacao_desc,
-        "resultados": resultados,
-        "protocolo": protocolos[0].text if protocolos else None,
-        "xml": xml_resp_str,
-        "xml_resposta": xml_resp_str,
-    }
+    return ResultadoManifestacao(
+        resultados=resultados,
+        protocolo=protocolos[0].text if protocolos else None,
+        xml=xml_resp_str,
+        xml_resposta=xml_resp_str,
+    )

--- a/nfe_sync/results.py
+++ b/nfe_sync/results.py
@@ -1,0 +1,68 @@
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True, slots=True)
+class Documento:
+    nsu: str
+    schema: str
+    nome: str | None = None
+    chave: str | None = None
+    xml: str | None = None
+    erro: str | None = None  # None = sucesso, str = descrição do erro
+
+
+@dataclass(frozen=True, slots=True)
+class ResultadoConsulta:
+    situacao: list  # list[dict] — [{status, motivo}]; vem do xml_utils
+    xml: str | None
+    xml_resposta: str
+
+
+@dataclass(frozen=True, slots=True)
+class ResultadoDfeChave:
+    sucesso: bool
+    status: str | None
+    motivo: str | None
+    documentos: list  # list[Documento]
+    xml_resposta: str
+    xml_cancelamento: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class ResultadoDistribuicao:
+    sucesso: bool
+    status: str | None
+    motivo: str | None
+    ultimo_nsu: int
+    max_nsu: int
+    documentos: list  # list[Documento]
+    xmls_resposta: list  # list[str]
+    estado: dict  # estado mutável; frozen impede re-atribuição do campo, não mutação
+
+
+@dataclass(frozen=True, slots=True)
+class ResultadoEmissao:
+    sucesso: bool
+    status: str | None
+    motivo: str | None
+    protocolo: str | None
+    chave: str | None
+    xml: str | None
+    xml_resposta: str | None
+    erros: list  # list[dict]
+
+
+@dataclass(frozen=True, slots=True)
+class ResultadoManifestacao:
+    resultados: list  # list[dict]
+    protocolo: str | None
+    xml: str
+    xml_resposta: str
+
+
+@dataclass(frozen=True, slots=True)
+class ResultadoInutilizacao:
+    resultados: list  # list[dict]
+    protocolo: str | None
+    xml: str
+    xml_resposta: str

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nfe-sync"
-version = "0.2.57"
+version = "0.2.59"
 requires-python = ">=3.12"
 dependencies = ["pynfe>=0.6.5", "python-dotenv", "pydantic>=2.0", "requests", "signxml"]
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,8 @@ import argparse
 import pytest
 from unittest.mock import patch, MagicMock
 
+from nfe_sync.results import ResultadoDistribuicao
+
 
 def _mock_empresas_hom():
     """Retorna empresa com homologacao=True (para testar override com --producao)."""
@@ -32,10 +34,10 @@ def _mock_empresas_prod():
     }
 
 
-_NSU_OK = {
-    "sucesso": True, "status": "137", "motivo": "OK",
-    "ultimo_nsu": 0, "max_nsu": 0, "documentos": [], "xmls_resposta": [], "estado": {},
-}
+_NSU_OK = ResultadoDistribuicao(
+    sucesso=True, status="137", motivo="OK",
+    ultimo_nsu=0, max_nsu=0, documentos=[], xmls_resposta=[], estado={},
+)
 
 
 class TestFlagsAmbientePos:

--- a/tests/test_consulta.py
+++ b/tests/test_consulta.py
@@ -77,9 +77,9 @@ class TestConsultarNsu:
         state_file = str(tmp_path / "state.json")
 
         resultado = consultar_nsu(empresa_sul, estado, state_file)
-        assert resultado["sucesso"] is False
-        assert "bloqueada" in resultado["motivo"]
-        assert resultado["documentos"] == []
+        assert resultado.sucesso is False
+        assert "bloqueada" in resultado.motivo
+        assert resultado.documentos == []
 
     @patch("nfe_sync.xml_utils.ComunicacaoSefaz")
     def test_nenhum_documento(self, mock_sefaz_cls, empresa_sul, tmp_path):
@@ -91,9 +91,9 @@ class TestConsultarNsu:
         estado = {}
 
         resultado = consultar_nsu(empresa_sul, estado, state_file)
-        assert resultado["sucesso"] is True
-        assert resultado["status"] == "137"
-        assert resultado["documentos"] == []
+        assert resultado.sucesso is True
+        assert resultado.status == "137"
+        assert resultado.documentos == []
 
     XML_COM_DOC_FINAL = b"""<?xml version="1.0" encoding="utf-8"?>
     <retDistDFeInt xmlns="http://www.portalfiscal.inf.br/nfe">
@@ -119,13 +119,13 @@ class TestConsultarNsu:
         estado = {}
 
         resultado = consultar_nsu(empresa_sul, estado, state_file)
-        assert resultado["sucesso"] is True
-        assert resultado["status"] == "138"
-        assert resultado["ultimo_nsu"] == 100
-        assert resultado["max_nsu"] == 100
-        assert len(resultado["documentos"]) == 2
-        assert resultado["documentos"][0]["nsu"] == "000000000000042"
-        assert resultado["documentos"][1]["nsu"] == "000000000000100"
+        assert resultado.sucesso is True
+        assert resultado.status == "138"
+        assert resultado.ultimo_nsu == 100
+        assert resultado.max_nsu == 100
+        assert len(resultado.documentos) == 2
+        assert resultado.documentos[0].nsu == "000000000000042"
+        assert resultado.documentos[1].nsu == "000000000000100"
 
         # verifica que salvou estado (sem cooldown quando baixou documentos com 138)
         estado_salvo = carregar_estado(state_file)
@@ -292,8 +292,8 @@ class TestProcessarDocsLogging:
             resultado = consultar_nsu(empresa_sul, {}, state_file)
 
         # O documento com erro deve estar na lista mas sem interromper
-        assert len(resultado["documentos"]) == 1
-        assert "erro" in resultado["documentos"][0]
+        assert len(resultado.documentos) == 1
+        assert resultado.documentos[0].erro is not None
         # O warning deve ter sido emitido
         assert any("000000000000001" in r.message for r in caplog.records)
 
@@ -326,7 +326,7 @@ class TestValidarChave:
             )
             mock_cls.return_value.consulta_nota.return_value = mock_resp
             resultado = consultar(empresa_sul, self.CHAVE_VALIDA)
-        assert resultado["situacao"] is not None
+        assert resultado.situacao is not None
 
     def test_consultar_dfe_chave_curta_levanta_erro(self, empresa_sul):
         with pytest.raises(NfeValidationError, match="44 digitos"):

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -1,0 +1,188 @@
+"""Testes para nfe_sync/results.py — Issue #25."""
+import pytest
+from dataclasses import FrozenInstanceError
+
+from nfe_sync.results import (
+    Documento,
+    ResultadoConsulta,
+    ResultadoDfeChave,
+    ResultadoDistribuicao,
+    ResultadoEmissao,
+    ResultadoManifestacao,
+    ResultadoInutilizacao,
+)
+
+
+class TestDocumento:
+    def test_sucesso_sem_erro(self):
+        doc = Documento(nsu="001", schema="procNFe_v4.00.xsd", nome="chave.xml",
+                        chave="chave", xml="<procNFe/>")
+        assert doc.nsu == "001"
+        assert doc.schema == "procNFe_v4.00.xsd"
+        assert doc.nome == "chave.xml"
+        assert doc.chave == "chave"
+        assert doc.xml == "<procNFe/>"
+        assert doc.erro is None
+
+    def test_erro_sem_nome_xml_chave(self):
+        doc = Documento(nsu="002", schema="resNFe_v1.01.xsd", erro="falha ao descompactar")
+        assert doc.erro == "falha ao descompactar"
+        assert doc.nome is None
+        assert doc.xml is None
+        assert doc.chave is None
+
+    def test_frozen_impede_atribuicao(self):
+        doc = Documento(nsu="001", schema="x")
+        with pytest.raises(FrozenInstanceError):
+            doc.nsu = "999"
+
+    def test_slots_impede_atributo_arbitrario(self):
+        doc = Documento(nsu="001", schema="x")
+        with pytest.raises((AttributeError, TypeError)):
+            doc.campo_inexistente = "y"
+
+
+class TestResultadoConsulta:
+    def test_campos_basicos(self):
+        r = ResultadoConsulta(
+            situacao=[{"status": "100", "motivo": "Autorizado"}],
+            xml="<procNFe/>",
+            xml_resposta="<retConsSitNFe/>",
+        )
+        assert r.situacao[0]["status"] == "100"
+        assert r.xml == "<procNFe/>"
+        assert r.xml_resposta == "<retConsSitNFe/>"
+
+    def test_xml_none_quando_erro(self):
+        r = ResultadoConsulta(
+            situacao=[{"status": "215", "motivo": "Rejeicao"}],
+            xml=None,
+            xml_resposta="<retConsSitNFe/>",
+        )
+        assert r.xml is None
+
+    def test_frozen(self):
+        r = ResultadoConsulta(situacao=[], xml=None, xml_resposta="<r/>")
+        with pytest.raises(FrozenInstanceError):
+            r.xml = "x"
+
+
+class TestResultadoDfeChave:
+    def test_sucesso(self):
+        doc = Documento(nsu="001", schema="procNFe_v4.00.xsd", xml="<x/>")
+        r = ResultadoDfeChave(
+            sucesso=True, status="138", motivo="Documento localizado",
+            documentos=[doc], xml_resposta="<r/>", xml_cancelamento=None,
+        )
+        assert r.sucesso is True
+        assert r.documentos[0].nsu == "001"
+        assert r.xml_cancelamento is None
+
+    def test_cancelamento(self):
+        r = ResultadoDfeChave(
+            sucesso=False, status="653", motivo="NF-e cancelada",
+            documentos=[], xml_resposta="<r/>", xml_cancelamento="<cancel/>",
+        )
+        assert r.xml_cancelamento == "<cancel/>"
+
+    def test_frozen(self):
+        r = ResultadoDfeChave(sucesso=False, status=None, motivo=None,
+                              documentos=[], xml_resposta="<r/>", xml_cancelamento=None)
+        with pytest.raises(FrozenInstanceError):
+            r.sucesso = True
+
+
+class TestResultadoDistribuicao:
+    def test_campos_completos(self):
+        estado = {"nsu": {"99999999000191": 42}}
+        r = ResultadoDistribuicao(
+            sucesso=True, status="137", motivo="Nenhum documento",
+            ultimo_nsu=42, max_nsu=42, documentos=[], xmls_resposta=["<r/>"],
+            estado=estado,
+        )
+        assert r.sucesso is True
+        assert r.ultimo_nsu == 42
+        assert r.estado["nsu"]["99999999000191"] == 42
+
+    def test_estado_mutavel_dentro_de_frozen(self):
+        estado = {}
+        r = ResultadoDistribuicao(
+            sucesso=False, status=None, motivo="bloqueado",
+            ultimo_nsu=0, max_nsu=0, documentos=[], xmls_resposta=[], estado=estado,
+        )
+        # Pode mutar o dict interno, mas não reatribuir o campo
+        r.estado["key"] = "val"
+        assert r.estado["key"] == "val"
+        with pytest.raises(FrozenInstanceError):
+            r.estado = {}
+
+    def test_cooldown_bloqueado(self):
+        r = ResultadoDistribuicao(
+            sucesso=False, status=None, motivo="Distribuicao DFe bloqueada ate 10:00:00 (60min restantes)",
+            ultimo_nsu=0, max_nsu=0, documentos=[], xmls_resposta=[], estado={},
+        )
+        assert r.sucesso is False
+        assert r.status is None
+        assert "bloqueada" in r.motivo
+
+
+class TestResultadoEmissao:
+    def test_sucesso(self):
+        r = ResultadoEmissao(
+            sucesso=True, status="100", motivo="Autorizado",
+            protocolo="123456789", chave="1" * 44,
+            xml="<nfeProc/>", xml_resposta=None, erros=[],
+        )
+        assert r.sucesso is True
+        assert r.protocolo == "123456789"
+        assert r.erros == []
+
+    def test_falha_com_erros(self):
+        r = ResultadoEmissao(
+            sucesso=False, status=None, motivo=None,
+            protocolo=None, chave=None, xml=None,
+            xml_resposta="<ret/>", erros=[{"status": "215", "motivo": "Rejeicao"}],
+        )
+        assert r.sucesso is False
+        assert r.erros[0]["status"] == "215"
+
+    def test_frozen(self):
+        r = ResultadoEmissao(sucesso=False, status=None, motivo=None,
+                             protocolo=None, chave=None, xml=None,
+                             xml_resposta=None, erros=[])
+        with pytest.raises(FrozenInstanceError):
+            r.sucesso = True
+
+
+class TestResultadoManifestacao:
+    def test_campos(self):
+        r = ResultadoManifestacao(
+            resultados=[{"status": "135", "motivo": "Evento registrado"}],
+            protocolo="999",
+            xml="<retEvento/>",
+            xml_resposta="<retEvento/>",
+        )
+        assert r.resultados[0]["status"] == "135"
+        assert r.protocolo == "999"
+
+    def test_frozen(self):
+        r = ResultadoManifestacao(resultados=[], protocolo=None, xml="<x/>", xml_resposta="<x/>")
+        with pytest.raises(FrozenInstanceError):
+            r.protocolo = "x"
+
+
+class TestResultadoInutilizacao:
+    def test_campos(self):
+        r = ResultadoInutilizacao(
+            resultados=[{"status": "102", "motivo": "Inutilizacao homologada"}],
+            protocolo="777",
+            xml="<retInutNFe/>",
+            xml_resposta="<retInutNFe/>",
+        )
+        assert r.resultados[0]["status"] == "102"
+        assert r.protocolo == "777"
+
+    def test_frozen(self):
+        r = ResultadoInutilizacao(resultados=[], protocolo=None, xml="<x/>", xml_resposta="<x/>")
+        with pytest.raises(FrozenInstanceError):
+            r.xml = "outro"


### PR DESCRIPTION
## Summary

- Cria `nfe_sync/results.py` com 7 dataclasses `frozen=True, slots=True`: `Documento`, `ResultadoConsulta`, `ResultadoDfeChave`, `ResultadoDistribuicao`, `ResultadoEmissao`, `ResultadoManifestacao`, `ResultadoInutilizacao`
- `Documento` unificado com campo `erro: str | None` (None = sucesso, str = descrição do erro)
- Todas as funções de operação NF-e agora retornam dataclasses em vez de dicts
- Comandos CLI atualizados para acesso por atributo (`resultado.sucesso` em vez de `resultado["sucesso"]`)

## Test plan

- [ ] 147 testes passando (`pytest tests/ -v`)
- [ ] `TestResultados` em `tests/test_results.py`: verifica instanciação, frozen (FrozenInstanceError/TypeError), campos obrigatórios e opcionais
- [ ] Testes existentes adaptados para usar objetos dataclass nos mocks

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)