### PR TITLE
refactor: #26 — DocumentoStorage centraliza I/O de arquivos NF-e

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.2.60
+- refactor: #26 — DocumentoStorage centraliza I/O de arquivos NF-e
+
 ## 0.2.59
 - refactor: #25 — dataclasses de retorno (ResultadoConsulta, ResultadoDistribuicao, etc.)
 

--- a/nfe_sync/storage.py
+++ b/nfe_sync/storage.py
@@ -1,0 +1,60 @@
+import logging
+import os
+
+from .xml_utils import safe_parse
+
+
+class DocumentoStorage:
+    """Centraliza todo I/O de arquivos de NF-e em downloads/{cnpj}/."""
+
+    BASE = "downloads"
+
+    def _pasta(self, cnpj: str) -> str:
+        return f"{self.BASE}/{cnpj}"
+
+    def salvar(self, cnpj: str, nome: str, xml: str) -> str:
+        pasta = self._pasta(cnpj)
+        os.makedirs(pasta, exist_ok=True)
+        caminho = f"{pasta}/{nome}"
+        with open(caminho, "w") as f:
+            f.write(xml)
+        return caminho
+
+    def existe(self, cnpj: str, nome: str) -> bool:
+        return os.path.exists(f"{self._pasta(cnpj)}/{nome}")
+
+    def root_tag(self, cnpj: str, nome: str) -> str | None:
+        try:
+            tree = safe_parse(f"{self._pasta(cnpj)}/{nome}")
+            tag = tree.getroot().tag
+            return tag.split("}")[-1] if "}" in tag else tag
+        except Exception as e:
+            logging.warning("Nao foi possivel ler %s/%s: %s", cnpj, nome, e)
+            return None
+
+    def listar_resumos_pendentes(self, cnpj: str) -> list[str]:
+        pasta = self._pasta(cnpj)
+        if not os.path.isdir(pasta):
+            return []
+        resumos = []
+        for nome in os.listdir(pasta):
+            if not nome.endswith(".xml"):
+                continue
+            try:
+                tag = self.root_tag(cnpj, nome)
+                if tag == "resNFe":
+                    resumos.append(nome[:-4])
+            except Exception as e:
+                logging.warning("Arquivo %s ignorado: %s", nome, e)
+        return resumos
+
+    def renomear(self, cnpj: str, origem: str, destino: str) -> str:
+        pasta = self._pasta(cnpj)
+        caminho_destino = f"{pasta}/{destino}"
+        os.rename(f"{pasta}/{origem}", caminho_destino)
+        return caminho_destino
+
+    def remover(self, cnpj: str, nome: str) -> None:
+        caminho = f"{self._pasta(cnpj)}/{nome}"
+        if os.path.exists(caminho):
+            os.remove(caminho)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nfe-sync"
-version = "0.2.59"
+version = "0.2.60"
 requires-python = ">=3.12"
 dependencies = ["pynfe>=0.6.5", "python-dotenv", "pydantic>=2.0", "requests", "signxml"]
 

--- a/tests/test_commands_consulta.py
+++ b/tests/test_commands_consulta.py
@@ -65,13 +65,13 @@ class TestListarResumosPendentes:
     def test_detecta_arquivo_com_nome_curto(self, tmp_path):
         """Arquivos com nome != 44 chars também devem ser detectados se root tag = resNFe."""
         from nfe_sync.commands import _listar_resumos_pendentes
-        import nfe_sync.commands as cmds_mod
+        import nfe_sync.storage as storage_mod
 
         cnpj = "99999999000191"
 
         with patch("os.path.isdir", return_value=True), \
              patch("os.listdir", return_value=["resumo-curto.xml", "outro.xml"]), \
-             patch.object(cmds_mod, "safe_parse") as mock_parse:
+             patch.object(storage_mod, "safe_parse") as mock_parse:
 
             def fake_parse(path):
                 mock_tree = MagicMock()
@@ -99,12 +99,12 @@ class TestListarResumosPendentes:
     def test_loga_warning_para_xml_invalido(self, tmp_path, caplog):
         """Issue #10: XML inválido deve gerar warning, não engolir silenciosamente."""
         from nfe_sync.commands import _listar_resumos_pendentes
-        import nfe_sync.commands as cmds_mod
+        import nfe_sync.storage as storage_mod
 
         cnpj = "99999999000191"
         with patch("os.path.isdir", return_value=True), \
              patch("os.listdir", return_value=["invalido.xml"]), \
-             patch.object(cmds_mod, "safe_parse", side_effect=Exception("xml quebrado")):
+             patch.object(storage_mod, "safe_parse", side_effect=Exception("xml quebrado")):
             with caplog.at_level(logging.WARNING):
                 resultado = _listar_resumos_pendentes(cnpj)
 
@@ -116,7 +116,7 @@ class TestTratarArquivoCancelado:
     """Issue #10: logging em _tratar_arquivo_cancelado."""
 
     def test_loga_warning_ao_falhar_leitura(self, tmp_path, caplog):
-        import nfe_sync.commands.consulta as consulta_cmds
+        import nfe_sync.storage as storage_mod
         from nfe_sync.commands.consulta import _tratar_arquivo_cancelado
 
         cnpj = "99999999000191"
@@ -124,7 +124,7 @@ class TestTratarArquivoCancelado:
 
         with patch("os.path.exists", return_value=True), \
              patch("os.rename"), \
-             patch.object(consulta_cmds, "safe_parse", side_effect=Exception("parse error")):
+             patch.object(storage_mod, "safe_parse", side_effect=Exception("parse error")):
             with caplog.at_level(logging.WARNING):
                 # Deve continuar sem levantar exceção
                 _tratar_arquivo_cancelado(cnpj, chave)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,107 @@
+"""Testes para storage.py — Issue #26."""
+import logging
+import pytest
+from unittest.mock import patch, MagicMock
+
+from nfe_sync.storage import DocumentoStorage
+
+
+class TestDocumentoStorage:
+
+    def test_salvar_cria_arquivo(self, tmp_path):
+        storage = DocumentoStorage()
+        storage.BASE = str(tmp_path)
+        caminho = storage.salvar("99999999000191", "nota.xml", "<nfe/>")
+        assert caminho.endswith("nota.xml")
+        with open(caminho) as f:
+            assert f.read() == "<nfe/>"
+
+    def test_existe_verdadeiro(self, tmp_path):
+        storage = DocumentoStorage()
+        storage.BASE = str(tmp_path)
+        storage.salvar("99999999000191", "nota.xml", "<nfe/>")
+        assert storage.existe("99999999000191", "nota.xml") is True
+
+    def test_existe_falso(self, tmp_path):
+        storage = DocumentoStorage()
+        storage.BASE = str(tmp_path)
+        assert storage.existe("99999999000191", "inexistente.xml") is False
+
+    def test_root_tag_retorna_tag_local(self, tmp_path):
+        storage = DocumentoStorage()
+        storage.BASE = str(tmp_path)
+        storage.salvar("99999999000191", "nota.xml",
+                       '<?xml version="1.0"?><resNFe xmlns="http://www.portalfiscal.inf.br/nfe"/>')
+        tag = storage.root_tag("99999999000191", "nota.xml")
+        assert tag == "resNFe"
+
+    def test_root_tag_retorna_none_e_loga_warning_em_falha(self, tmp_path, caplog):
+        storage = DocumentoStorage()
+        storage.BASE = str(tmp_path)
+        import nfe_sync.storage as storage_mod
+        with patch.object(storage_mod, "safe_parse", side_effect=Exception("parse error")):
+            with caplog.at_level(logging.WARNING):
+                tag = storage.root_tag("99999999000191", "invalido.xml")
+        assert tag is None
+        assert any("parse error" in r.message for r in caplog.records)
+
+    def test_listar_resumos_pendentes_detecta_resnfe(self, tmp_path):
+        storage = DocumentoStorage()
+        storage.BASE = str(tmp_path)
+        cnpj = "99999999000191"
+        import nfe_sync.storage as storage_mod
+
+        with patch("os.path.isdir", return_value=True), \
+             patch("os.listdir", return_value=["resumo.xml", "proc.xml"]), \
+             patch.object(storage_mod, "safe_parse") as mock_parse:
+
+            def fake_parse(path):
+                tree = MagicMock()
+                if path.endswith("resumo.xml"):
+                    tree.getroot.return_value.tag = "{http://www.portalfiscal.inf.br/nfe}resNFe"
+                else:
+                    tree.getroot.return_value.tag = "procNFe"
+                return tree
+
+            mock_parse.side_effect = fake_parse
+            resultado = storage.listar_resumos_pendentes(cnpj)
+
+        assert "resumo" in resultado
+        assert "proc" not in resultado
+
+    def test_listar_resumos_pendentes_pasta_inexistente(self, tmp_path):
+        storage = DocumentoStorage()
+        storage.BASE = str(tmp_path)
+        resultado = storage.listar_resumos_pendentes("00000000000000")
+        assert resultado == []
+
+    def test_listar_resumos_ignora_nao_xml(self, tmp_path):
+        storage = DocumentoStorage()
+        storage.BASE = str(tmp_path)
+        cnpj = "99999999000191"
+        with patch("os.path.isdir", return_value=True), \
+             patch("os.listdir", return_value=["arquivo.txt", "foto.pdf"]):
+            resultado = storage.listar_resumos_pendentes(cnpj)
+        assert resultado == []
+
+    def test_renomear(self, tmp_path):
+        storage = DocumentoStorage()
+        storage.BASE = str(tmp_path)
+        storage.salvar("99999999000191", "orig.xml", "<nfe/>")
+        destino = storage.renomear("99999999000191", "orig.xml", "dest.xml")
+        assert destino.endswith("dest.xml")
+        assert storage.existe("99999999000191", "dest.xml")
+        assert not storage.existe("99999999000191", "orig.xml")
+
+    def test_remover(self, tmp_path):
+        storage = DocumentoStorage()
+        storage.BASE = str(tmp_path)
+        storage.salvar("99999999000191", "nota.xml", "<nfe/>")
+        storage.remover("99999999000191", "nota.xml")
+        assert not storage.existe("99999999000191", "nota.xml")
+
+    def test_remover_inexistente_nao_levanta(self, tmp_path):
+        storage = DocumentoStorage()
+        storage.BASE = str(tmp_path)
+        # Não deve levantar exceção
+        storage.remover("99999999000191", "inexistente.xml")


### PR DESCRIPTION
## Summary

- Cria `nfe_sync/storage.py` com `DocumentoStorage`: centraliza todo I/O de arquivos em `downloads/{cnpj}/`
- Métodos: `salvar`, `existe`, `root_tag`, `listar_resumos_pendentes`, `renomear`, `remover`
- `commands/__init__.py`: `_salvar_xml` e `_listar_resumos_pendentes` delegam para `_storage` (instância global)
- `commands/consulta.py`: `_tratar_arquivo_cancelado` usa `_storage` em vez de `os`/`safe_parse` diretos

## Test plan

- [ ] 158 testes passando (`pytest tests/ -v`)
- [ ] `tests/test_storage.py`: 11 testes cobrindo todos os métodos de `DocumentoStorage`
- [ ] Testes existentes de `test_commands_consulta.py` atualizados com patch em `nfe_sync.storage.safe_parse`

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)