### PR TITLE
refactor: #27 — extrair chamar_sefaz() e mover _com_retry para xml_utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.2.61
+- refactor: #27 — extrair chamar_sefaz() e mover _com_retry para xml_utils
+
 ## 0.2.60
 - refactor: #26 — DocumentoStorage centraliza I/O de arquivos NF-e
 

--- a/nfe_sync/manifestacao.py
+++ b/nfe_sync/manifestacao.py
@@ -5,7 +5,7 @@ from pynfe.processamento.assinatura import AssinaturaA1
 
 from .models import EmpresaConfig, validar_cnpj_sefaz
 from .exceptions import NfeValidationError
-from .xml_utils import to_xml_string, extract_status_motivo, criar_comunicacao, safe_fromstring, agora_brt
+from .xml_utils import extract_status_motivo, agora_brt, chamar_sefaz
 from .results import ResultadoManifestacao
 
 
@@ -67,11 +67,7 @@ def manifestar(
     assinatura = AssinaturaA1(empresa.certificado.path, empresa.certificado.senha)
     xml_assinado = assinatura.assinar(xml_evento)
 
-    con = criar_comunicacao(empresa)
-    resposta = con.evento(modelo="nfe", evento=xml_assinado)
-
-    xml_resp = safe_fromstring(resposta.content)
-    xml_resp_str = to_xml_string(xml_resp)
+    xml_resp, xml_resp_str = chamar_sefaz(empresa, "evento", modelo="nfe", evento=xml_assinado)
     resultados = extract_status_motivo(xml_resp, NS)
     protocolos = xml_resp.xpath("//ns:nProt", namespaces=NS)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nfe-sync"
-version = "0.2.60"
+version = "0.2.61"
 requires-python = ">=3.12"
 dependencies = ["pynfe>=0.6.5", "python-dotenv", "pydantic>=2.0", "requests", "signxml"]
 

--- a/tests/test_xml_utils.py
+++ b/tests/test_xml_utils.py
@@ -1,8 +1,9 @@
-"""Testes para xml_utils.py — Issues #3 (XXE) e #11 (timeout)."""
+"""Testes para xml_utils.py — Issues #3 (XXE), #11 (timeout), #27 (chamar_sefaz)."""
 import pytest
 from pynfe.utils import etree
+from unittest.mock import patch, MagicMock, call
 
-from nfe_sync.xml_utils import safe_fromstring, safe_parse, criar_comunicacao
+from nfe_sync.xml_utils import safe_fromstring, safe_parse, criar_comunicacao, chamar_sefaz, _com_retry
 
 
 class TestSafeFromstring:
@@ -107,3 +108,77 @@ class TestCriarComunicacao:
 
         con._post("http://sefaz", "<xml/>", timeout=60)
         assert chamadas == [60]
+
+
+class TestChamarSefaz:
+    """Issue #27: chamar_sefaz centraliza retry + parsing de resposta."""
+
+    XML_RESP = b'<retConsSitNFe xmlns="http://www.portalfiscal.inf.br/nfe"><cStat>100</cStat></retConsSitNFe>'
+
+    def test_chama_metodo_correto(self, empresa_sul):
+        mock_resp = MagicMock()
+        mock_resp.content = self.XML_RESP
+        with patch("nfe_sync.xml_utils.ComunicacaoSefaz") as mock_cls:
+            mock_cls.return_value.consulta_nota.return_value = mock_resp
+            xml_el, xml_str = chamar_sefaz(empresa_sul, "consulta_nota", modelo="nfe", chave="x")
+
+        mock_cls.return_value.consulta_nota.assert_called_once_with(modelo="nfe", chave="x")
+
+    def test_retorna_elemento_e_string(self, empresa_sul):
+        mock_resp = MagicMock()
+        mock_resp.content = self.XML_RESP
+        with patch("nfe_sync.xml_utils.ComunicacaoSefaz") as mock_cls:
+            mock_cls.return_value.consulta_nota.return_value = mock_resp
+            xml_el, xml_str = chamar_sefaz(empresa_sul, "consulta_nota", modelo="nfe", chave="x")
+
+        assert "retConsSitNFe" in xml_el.tag
+        assert "<?xml" in xml_str
+        assert "retConsSitNFe" in xml_str
+
+    def test_usa_uf_fornecida(self, empresa_sul):
+        mock_resp = MagicMock()
+        mock_resp.content = self.XML_RESP
+        with patch("nfe_sync.xml_utils.ComunicacaoSefaz") as mock_cls:
+            mock_cls.return_value.consulta_nota.return_value = mock_resp
+            chamar_sefaz(empresa_sul, "consulta_nota", uf="rj", modelo="nfe", chave="x")
+
+        mock_cls.assert_called_once_with(
+            "rj",
+            empresa_sul.certificado.path,
+            empresa_sul.certificado.senha,
+            empresa_sul.homologacao,
+        )
+
+    def test_usa_uf_empresa_quando_nao_fornecida(self, empresa_sul):
+        mock_resp = MagicMock()
+        mock_resp.content = self.XML_RESP
+        with patch("nfe_sync.xml_utils.ComunicacaoSefaz") as mock_cls:
+            mock_cls.return_value.consulta_nota.return_value = mock_resp
+            chamar_sefaz(empresa_sul, "consulta_nota", modelo="nfe", chave="x")
+
+        mock_cls.assert_called_once_with(
+            empresa_sul.uf,
+            empresa_sul.certificado.path,
+            empresa_sul.certificado.senha,
+            empresa_sul.homologacao,
+        )
+
+    def test_aplica_retry_em_falha(self, empresa_sul):
+        mock_resp = MagicMock()
+        mock_resp.content = self.XML_RESP
+        with patch("nfe_sync.xml_utils.ComunicacaoSefaz") as mock_cls, \
+             patch("nfe_sync.xml_utils.time.sleep"):
+            mock_cls.return_value.consulta_nota.side_effect = [
+                RuntimeError("timeout"), mock_resp
+            ]
+            xml_el, xml_str = chamar_sefaz(empresa_sul, "consulta_nota", modelo="nfe", chave="x")
+
+        assert mock_cls.return_value.consulta_nota.call_count == 2
+
+    def test_trata_resposta_sem_content(self, empresa_sul):
+        """Resposta que é bytes diretamente (sem .content) também deve funcionar."""
+        with patch("nfe_sync.xml_utils.ComunicacaoSefaz") as mock_cls:
+            mock_cls.return_value.consulta_nota.return_value = self.XML_RESP
+            xml_el, xml_str = chamar_sefaz(empresa_sul, "consulta_nota", modelo="nfe", chave="x")
+
+        assert "retConsSitNFe" in xml_el.tag


### PR DESCRIPTION
## Summary

- Move `_com_retry` de `consulta.py` para `xml_utils.py` (compartilhável por todos os módulos)
- Adiciona `chamar_sefaz(empresa, fn_nome, *args, uf=None, **kwargs)` em `xml_utils.py`: centraliza `criar_comunicacao → _com_retry → safe_fromstring → to_xml_string`
- `consultar()` e `consultar_dfe_chave()` refatorados para usar `chamar_sefaz()`
- `manifestar()` refatorado para usar `chamar_sefaz()`
- `consultar_nsu()` mantido com loop de paginação direto (não se beneficia do helper genérico)

## Test plan

- [ ] 164 testes passando (`pytest tests/ -v`)
- [ ] `tests/test_xml_utils.py`: `TestChamarSefaz` com 6 testes cobrindo método chamado, retry, UF, retorno (el, str) e resposta sem `.content`
- [ ] Patch target de `time.sleep` atualizado para `nfe_sync.xml_utils.time.sleep`

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)