### PR TITLE
fix: #40 — mensagem amigável quando emitente sem endereço configurado

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.2.68
+- fix: #40 — mensagem amigavel quando emitente sem endereco configurado
+
 ## 0.2.67
 - refactor: #28 — tipar CallbackProgresso e adicionar testes de contrato
 

--- a/nfe_sync/commands/emissao.py
+++ b/nfe_sync/commands/emissao.py
@@ -27,6 +27,12 @@ def cmd_emitir(args):
     emi = empresa.emitente
     end = emi.endereco
 
+    if end is None:
+        print("Erro: Emitente sem endereco configurado.")
+        print("Preencha os dados cadastrais com:")
+        print(f"  api_cli cnpjws {emi.cnpj} --salvar-ini {empresa.nome}")
+        sys.exit(1)
+
     dados = DadosEmissao(
         destinatario=Destinatario(
             razao_social="NF-E EMITIDA EM AMBIENTE DE HOMOLOGACAO - SEM VALOR FISCAL",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nfe-sync"
-version = "0.2.67"
+version = "0.2.68"
 requires-python = ">=3.12"
 dependencies = ["pynfe>=0.6.5", "python-dotenv", "pydantic>=2.0", "requests", "signxml"]
 

--- a/tests/test_commands_emissao.py
+++ b/tests/test_commands_emissao.py
@@ -1,0 +1,82 @@
+"""Testes para commands/emissao.py — Issue #40."""
+import pytest
+from unittest.mock import patch, MagicMock
+
+from nfe_sync.models import EmpresaConfig, Certificado, Emitente, Endereco
+
+
+@pytest.fixture
+def empresa_sem_endereco():
+    return EmpresaConfig(
+        nome="SUL",
+        certificado=Certificado(path="/tmp/cert.pfx", senha="123456"),
+        emitente=Emitente(cnpj="99999999000191"),
+        uf="sp",
+        homologacao=True,
+    )
+
+
+@pytest.fixture
+def empresa_com_endereco():
+    return EmpresaConfig(
+        nome="SUL",
+        certificado=Certificado(path="/tmp/cert.pfx", senha="123456"),
+        emitente=Emitente(
+            cnpj="99999999000191",
+            endereco=Endereco(
+                logradouro="RUA EXEMPLO",
+                numero="100",
+                bairro="CENTRO",
+                municipio="SAO PAULO",
+                cod_municipio="3550308",
+                uf="SP",
+                cep="01310100",
+            ),
+        ),
+        uf="sp",
+        homologacao=True,
+    )
+
+
+class TestCmdEmitirSemEndereco:
+    """Issue #40: mensagem amigável quando endereco é None."""
+
+    def _make_args(self, empresa):
+        args = MagicMock()
+        args.empresa = empresa.nome
+        args.serie = "1"
+        args.homologacao = True
+        args.producao = False
+        return args
+
+    def test_exit_code_1_sem_endereco(self, empresa_sem_endereco, capsys):
+        from nfe_sync.commands.emissao import cmd_emitir
+
+        args = self._make_args(empresa_sem_endereco)
+        with patch("nfe_sync.commands.emissao._carregar", return_value=(empresa_sem_endereco, {})):
+            with pytest.raises(SystemExit) as exc:
+                cmd_emitir(args)
+
+        assert exc.value.code == 1
+
+    def test_mensagem_amigavel_sem_endereco(self, empresa_sem_endereco, capsys):
+        from nfe_sync.commands.emissao import cmd_emitir
+
+        args = self._make_args(empresa_sem_endereco)
+        with patch("nfe_sync.commands.emissao._carregar", return_value=(empresa_sem_endereco, {})):
+            with pytest.raises(SystemExit):
+                cmd_emitir(args)
+
+        out = capsys.readouterr().out
+        assert "endereco" in out.lower()
+        assert "api_cli" in out
+
+    def test_sem_traceback_sem_endereco(self, empresa_sem_endereco, capsys):
+        """Não deve levantar AttributeError — apenas SystemExit com mensagem."""
+        from nfe_sync.commands.emissao import cmd_emitir
+
+        args = self._make_args(empresa_sem_endereco)
+        with patch("nfe_sync.commands.emissao._carregar", return_value=(empresa_sem_endereco, {})):
+            with pytest.raises(SystemExit):
+                cmd_emitir(args)
+        # Se chegou aqui sem AttributeError, o teste passou


### PR DESCRIPTION
## Resumo

- Substitui `AttributeError: 'NoneType' object has no attribute 'logradouro'` por mensagem amigável
- Valida `emi.endereco is None` antes de construir `DadosEmissao`
- Instrui o usuário a usar `api_cli cnpjws <CNPJ> --salvar-ini EMPRESA`

## Mudanças

- `commands/emissao.py`: null check com `sys.exit(1)` e mensagem clara
- `tests/test_commands_emissao.py`: 3 testes cobrindo exit code, mensagem e ausência de traceback

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)