### PR TITLE
fix: #41 — exit code 1 quando SEFAZ rejeita inutilização

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.2.68
 - fix: #40 — mensagem amigavel quando emitente sem endereco configurado
+- fix: #41 — exit code 1 quando SEFAZ rejeita inutilizacao
 
 ## 0.2.67
 - refactor: #28 — tipar CallbackProgresso e adicionar testes de contrato

--- a/nfe_sync/commands/inutilizacao.py
+++ b/nfe_sync/commands/inutilizacao.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import sys
 
 from . import CliBlueprint, _carregar, _salvar_log_xml
 
@@ -30,6 +31,9 @@ def cmd_inutilizar(args):
     if resultado.protocolo:
         print(f"  Protocolo: {resultado.protocolo}")
     print(f"  Resposta salva em: {arquivo}")
+
+    if not resultado.sucesso:
+        sys.exit(1)
 
 
 class InutilizacaoBlueprint(CliBlueprint):

--- a/nfe_sync/inutilizacao.py
+++ b/nfe_sync/inutilizacao.py
@@ -39,6 +39,7 @@ def inutilizar(
     protocolos = xml_resp.xpath("//ns:nProt", namespaces=NS)
 
     return ResultadoInutilizacao(
+        sucesso=any(r["status"] == "102" for r in resultados),
         resultados=resultados,
         protocolo=protocolos[0].text if protocolos else None,
         xml=xml_resp_str,

--- a/nfe_sync/results.py
+++ b/nfe_sync/results.py
@@ -62,6 +62,7 @@ class ResultadoManifestacao:
 
 @dataclass(frozen=True, slots=True)
 class ResultadoInutilizacao:
+    sucesso: bool  # True se algum cStat == "102"
     resultados: list  # list[dict]
     protocolo: str | None
     xml: str

--- a/tests/test_commands_inutilizacao.py
+++ b/tests/test_commands_inutilizacao.py
@@ -1,0 +1,79 @@
+"""Testes para commands/inutilizacao.py — Issue #41."""
+import pytest
+from unittest.mock import patch, MagicMock
+
+from nfe_sync.results import ResultadoInutilizacao
+
+
+def _make_resultado(sucesso, c_stat, motivo):
+    return ResultadoInutilizacao(
+        sucesso=sucesso,
+        resultados=[{"status": c_stat, "motivo": motivo}],
+        protocolo="123456789" if sucesso else None,
+        xml="<inutNFe/>",
+        xml_resposta="<retInutNFe/>",
+    )
+
+
+def _make_args(empresa):
+    args = MagicMock()
+    args.empresa = empresa.nome
+    args.serie = "1"
+    args.inicio = 900000
+    args.fim = 900000
+    args.justificativa = "Numeracao nao utilizada no sistema"
+    args.homologacao = True
+    args.producao = False
+    return args
+
+
+class TestCmdInutilizarExitCode:
+    """Issue #41: exit code 1 quando SEFAZ rejeita inutilizacao."""
+
+    def test_exit_0_quando_sucesso(self, empresa_sul, tmp_path, capsys):
+        from nfe_sync.commands.inutilizacao import cmd_inutilizar
+
+        resultado = _make_resultado(True, "102", "Inutilizacao de numero homologado")
+        args = _make_args(empresa_sul)
+
+        with patch("nfe_sync.commands.inutilizacao._carregar", return_value=(empresa_sul, {})), \
+             patch("nfe_sync.inutilizacao.inutilizar", return_value=resultado), \
+             patch("nfe_sync.commands.inutilizacao._salvar_log_xml"), \
+             patch("nfe_sync.commands.inutilizacao.os.makedirs"), \
+             patch("builtins.open", MagicMock()):
+            cmd_inutilizar(args)  # não deve levantar SystemExit
+
+    def test_exit_1_quando_rejeicao(self, empresa_sul, capsys):
+        from nfe_sync.commands.inutilizacao import cmd_inutilizar
+
+        resultado = _make_resultado(False, "266", "Rejeicao: Serie utilizada nao permitida no Web Service")
+        args = _make_args(empresa_sul)
+
+        with patch("nfe_sync.commands.inutilizacao._carregar", return_value=(empresa_sul, {})), \
+             patch("nfe_sync.inutilizacao.inutilizar", return_value=resultado), \
+             patch("nfe_sync.commands.inutilizacao._salvar_log_xml"), \
+             patch("nfe_sync.commands.inutilizacao.os.makedirs"), \
+             patch("builtins.open", MagicMock()):
+            with pytest.raises(SystemExit) as exc:
+                cmd_inutilizar(args)
+
+        assert exc.value.code == 1
+
+    def test_resultado_impresso_antes_exit(self, empresa_sul, capsys):
+        """Mesmo em caso de erro, o cStat é impresso antes do exit."""
+        from nfe_sync.commands.inutilizacao import cmd_inutilizar
+
+        resultado = _make_resultado(False, "266", "Rejeicao: Serie utilizada nao permitida")
+        args = _make_args(empresa_sul)
+
+        with patch("nfe_sync.commands.inutilizacao._carregar", return_value=(empresa_sul, {})), \
+             patch("nfe_sync.inutilizacao.inutilizar", return_value=resultado), \
+             patch("nfe_sync.commands.inutilizacao._salvar_log_xml"), \
+             patch("nfe_sync.commands.inutilizacao.os.makedirs"), \
+             patch("builtins.open", MagicMock()):
+            with pytest.raises(SystemExit):
+                cmd_inutilizar(args)
+
+        out = capsys.readouterr().out
+        assert "266" in out
+        assert "RESULTADO" in out

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -174,15 +174,17 @@ class TestResultadoManifestacao:
 class TestResultadoInutilizacao:
     def test_campos(self):
         r = ResultadoInutilizacao(
+            sucesso=True,
             resultados=[{"status": "102", "motivo": "Inutilizacao homologada"}],
             protocolo="777",
             xml="<retInutNFe/>",
             xml_resposta="<retInutNFe/>",
         )
+        assert r.sucesso is True
         assert r.resultados[0]["status"] == "102"
         assert r.protocolo == "777"
 
     def test_frozen(self):
-        r = ResultadoInutilizacao(resultados=[], protocolo=None, xml="<x/>", xml_resposta="<x/>")
+        r = ResultadoInutilizacao(sucesso=False, resultados=[], protocolo=None, xml="<x/>", xml_resposta="<x/>")
         with pytest.raises(FrozenInstanceError):
             r.xml = "outro"


### PR DESCRIPTION
## Resumo

- `cmd_inutilizar` agora retorna exit code 1 quando `resultado.sucesso is False`
- Adiciona campo `sucesso: bool` a `ResultadoInutilizacao` (consistente com os outros resultado types)
- `inutilizar()` calcula `sucesso = any(r["status"] == "102" for r in resultados)`

## Mudanças

- `results.py`: adiciona `sucesso: bool` a `ResultadoInutilizacao`
- `inutilizacao.py`: popula `sucesso` no retorno
- `commands/inutilizacao.py`: `sys.exit(1)` quando `not resultado.sucesso`
- `tests/test_commands_inutilizacao.py`: 3 testes (exit 0 sucesso, exit 1 rejeição, output antes do exit)
- `tests/test_results.py`: atualiza testes existentes com o novo campo

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)