### PR TITLE
fix: #44 — config.py carrega campos de endereço do INI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.2.69
+- fix: #44 — config.py carrega campos de endereco do INI
+
 ## 0.2.68
 - fix: #40 — mensagem amigavel quando emitente sem endereco configurado
 - fix: #41 — exit code 1 quando SEFAZ rejeita inutilizacao

--- a/nfe_sync/config.py
+++ b/nfe_sync/config.py
@@ -1,7 +1,7 @@
 import configparser
 
 from .exceptions import NfeConfigError
-from .models import Certificado, Emitente, EmpresaConfig
+from .models import Certificado, Emitente, Endereco, EmpresaConfig
 
 
 CAMPOS_OBRIGATORIOS = ("path", "senha", "uf", "homologacao", "cnpj")
@@ -23,6 +23,26 @@ def _parse_secao(nome: str, secao: configparser.SectionProxy) -> EmpresaConfig:
         senha=secao["senha"],
     )
 
+    logradouro = secao.get("logradouro", "")
+    bairro = secao.get("bairro", "")
+    municipio = secao.get("municipio", "")
+    cod_municipio = secao.get("cod_municipio", "")
+    cep = secao.get("cep", "")
+    endereco_uf = secao.get("endereco_uf", "") or secao.get("uf", "").upper()
+
+    endereco = None
+    if logradouro and bairro and municipio and cod_municipio and cep:
+        endereco = Endereco(
+            logradouro=logradouro,
+            numero=secao.get("numero", ""),
+            complemento=secao.get("complemento", ""),
+            bairro=bairro,
+            municipio=municipio,
+            cod_municipio=cod_municipio,
+            uf=endereco_uf,
+            cep=cep,
+        )
+
     emitente = Emitente(
         cnpj=secao["cnpj"],
         razao_social=secao.get("razao_social", ""),
@@ -30,6 +50,7 @@ def _parse_secao(nome: str, secao: configparser.SectionProxy) -> EmpresaConfig:
         inscricao_estadual=secao.get("inscricao_estadual", ""),
         cnae_fiscal=secao.get("cnae_fiscal", ""),
         regime_tributario=secao.get("regime_tributario", ""),
+        endereco=endereco,
     )
 
     return EmpresaConfig(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nfe-sync"
-version = "0.2.68"
+version = "0.2.69"
 requires-python = ">=3.12"
 dependencies = ["pynfe>=0.6.5", "python-dotenv", "pydantic>=2.0", "requests", "signxml"]
 

--- a/tests/test_nfe_config.py
+++ b/tests/test_nfe_config.py
@@ -20,6 +20,26 @@ cnae_fiscal = 4783101
 regime_tributario = 1
 """
 
+INI_COM_ENDERECO = INI_COMPLETO + """\
+logradouro = RUA EXEMPLO
+numero = 100
+complemento = SALA 01
+bairro = CENTRO
+municipio = SAO PAULO
+cod_municipio = 3550308
+endereco_uf = SP
+cep = 01310100
+"""
+
+INI_SEM_COD_MUNICIPIO = INI_COMPLETO + """\
+logradouro = RUA EXEMPLO
+numero = 100
+bairro = CENTRO
+municipio = SAO PAULO
+cod_municipio =
+cep = 01310100
+"""
+
 
 class TestCarregarEmpresas:
     def test_carregar_config_minimo(self, tmp_path):
@@ -53,6 +73,36 @@ class TestCarregarEmpresas:
         ini.write_text("[SUL]\npath = /tmp/cert.pfx\nsenha = 123456\n")
         with pytest.raises(NfeConfigError, match="Campos obrigatorios faltando"):
             carregar_empresas(str(ini))
+
+
+class TestCarregarEndereco:
+    """Issue #44: config.py deve carregar campos de endereço do INI."""
+
+    def test_endereco_carregado_quando_completo(self, tmp_path):
+        ini = tmp_path / "test.ini"
+        ini.write_text(INI_COM_ENDERECO)
+        emp = carregar_empresas(str(ini))["SUL"]
+        end = emp.emitente.endereco
+        assert end is not None
+        assert end.logradouro == "RUA EXEMPLO"
+        assert end.bairro == "CENTRO"
+        assert end.municipio == "SAO PAULO"
+        assert end.cod_municipio == "3550308"
+        assert end.cep == "01310100"
+        assert end.uf == "SP"
+
+    def test_endereco_none_quando_sem_ini(self, tmp_path):
+        ini = tmp_path / "test.ini"
+        ini.write_text(INI_MINIMO)
+        emp = carregar_empresas(str(ini))["SUL"]
+        assert emp.emitente.endereco is None
+
+    def test_endereco_none_quando_cod_municipio_vazio(self, tmp_path):
+        """Sem cod_municipio, endereco não é construído (campo obrigatório para SEFAZ)."""
+        ini = tmp_path / "test.ini"
+        ini.write_text(INI_SEM_COD_MUNICIPIO)
+        emp = carregar_empresas(str(ini))["SUL"]
+        assert emp.emitente.endereco is None
 
 
 class TestParseHomologacao:


### PR DESCRIPTION
## Resumo

- `_parse_secao()` agora lê os campos de endereço do INI e constrói `Endereco` quando todos os campos obrigatórios estão presentes
- Resolve o ciclo impossível: `api_cli cnpjws --salvar-ini` salvava o endereço, mas `config.py` nunca o carregava → `emitente.endereco` sempre `None`

## Mudanças

- `nfe_sync/config.py`: lê `logradouro`, `bairro`, `municipio`, `cod_municipio`, `cep`, `endereco_uf` do INI; constrói `Endereco` se campos obrigatórios presentes
- `tests/test_nfe_config.py`: adiciona `TestCarregarEndereco` com 3 testes (endereço completo, sem endereço, cod_municipio vazio)

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)