### PR TITLE
fix: #46 — cnpjws extrai cod_municipio do ibge_id e salva no INI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.2.69
 - fix: #44 — config.py carrega campos de endereco do INI
+- fix: #46 — cnpjws extrai cod_municipio do ibge_id e salva no INI
 
 ## 0.2.68
 - fix: #40 — mensagem amigavel quando emitente sem endereco configurado

--- a/nfe_sync/apis/cli.py
+++ b/nfe_sync/apis/cli.py
@@ -70,7 +70,7 @@ def _salvar_ini(empresa, nome_secao: str):
     cfg.set(nome_secao, "complemento", end.complemento or "")
     cfg.set(nome_secao, "bairro", end.bairro)
     cfg.set(nome_secao, "municipio", end.municipio)
-    cfg.set(nome_secao, "cod_municipio", "")
+    cfg.set(nome_secao, "cod_municipio", end.cod_municipio)
     cfg.set(nome_secao, "endereco_uf", end.uf.upper())
     cfg.set(nome_secao, "cep", str(end.cep))
 

--- a/nfe_sync/apis/cnpjws.py
+++ b/nfe_sync/apis/cnpjws.py
@@ -11,6 +11,7 @@ class CnpjwsEndereco(BaseModel, extra="allow"):
     complemento: str = ""
     bairro: str = ""
     municipio: str = ""
+    cod_municipio: str = ""
     uf: str = ""
     cep: str = ""
 
@@ -35,7 +36,9 @@ class CnpjwsEmpresa(BaseModel, extra="allow"):
     @classmethod
     def from_api(cls, dados: dict) -> "CnpjwsEmpresa":
         est = dados.get("estabelecimento", {})
-        municipio = est.get("cidade", {}).get("nome", "") if isinstance(est.get("cidade"), dict) else est.get("municipio", "")
+        cidade = est.get("cidade", {}) if isinstance(est.get("cidade"), dict) else {}
+        municipio = cidade.get("nome", "") or est.get("municipio", "")
+        cod_municipio = str(cidade.get("ibge_id", "")) if cidade.get("ibge_id") else ""
         estado = est.get("estado", {}).get("sigla", "") if isinstance(est.get("estado"), dict) else est.get("uf", "")
         endereco = CnpjwsEndereco(
             logradouro=f"{est.get('tipo_logradouro', '')} {est.get('logradouro', '')}".strip(),
@@ -43,6 +46,7 @@ class CnpjwsEmpresa(BaseModel, extra="allow"):
             complemento=est.get("complemento", ""),
             bairro=est.get("bairro", ""),
             municipio=municipio,
+            cod_municipio=cod_municipio,
             uf=estado,
             cep=est.get("cep", ""),
         )

--- a/tests/test_cnpjws.py
+++ b/tests/test_cnpjws.py
@@ -1,0 +1,63 @@
+"""Testes para apis/cnpjws.py — Issue #46: cod_municipio extraído do ibge_id."""
+from nfe_sync.apis.cnpjws import CnpjwsEmpresa
+
+DADOS_API = {
+    "razao_social": "EMPRESA TESTE LTDA",
+    "estabelecimento": {
+        "cnpj": "99999999000191",
+        "nome_fantasia": "EMPRESA TESTE",
+        "situacao_cadastral": "Ativa",
+        "data_inicio_atividade": "2000-01-01",
+        "tipo_logradouro": "RUA",
+        "logradouro": "EXEMPLO",
+        "numero": "100",
+        "complemento": "",
+        "bairro": "CENTRO",
+        "cidade": {
+            "id": 5564,
+            "nome": "SAO PAULO",
+            "ibge_id": 3550308,
+            "siafi_id": "7107",
+        },
+        "estado": {"sigla": "SP"},
+        "cep": "01310100",
+        "atividade_principal": {"id": 4783101, "descricao": "Comercio varejista"},
+        "inscricoes_estaduais": [],
+    },
+}
+
+DADOS_SEM_IBGE = {
+    "razao_social": "EMPRESA TESTE LTDA",
+    "estabelecimento": {
+        "cnpj": "99999999000191",
+        "nome_fantasia": "",
+        "situacao_cadastral": "Ativa",
+        "data_inicio_atividade": "2000-01-01",
+        "tipo_logradouro": "",
+        "logradouro": "RUA EXEMPLO",
+        "numero": "100",
+        "complemento": "",
+        "bairro": "CENTRO",
+        "cidade": {"id": 5564, "nome": "SAO PAULO"},  # sem ibge_id
+        "estado": {"sigla": "SP"},
+        "cep": "01310100",
+        "atividade_principal": {"id": 0, "descricao": ""},
+        "inscricoes_estaduais": [],
+    },
+}
+
+
+class TestCnpjwsFromApi:
+    """Issue #46: cod_municipio deve ser extraído do ibge_id da API."""
+
+    def test_cod_municipio_extraido_do_ibge_id(self):
+        empresa = CnpjwsEmpresa.from_api(DADOS_API)
+        assert empresa.endereco.cod_municipio == "3550308"
+
+    def test_cod_municipio_vazio_sem_ibge_id(self):
+        empresa = CnpjwsEmpresa.from_api(DADOS_SEM_IBGE)
+        assert empresa.endereco.cod_municipio == ""
+
+    def test_municipio_extraido_do_nome(self):
+        empresa = CnpjwsEmpresa.from_api(DADOS_API)
+        assert empresa.endereco.municipio == "SAO PAULO"


### PR DESCRIPTION
## Resumo

- `CnpjwsEndereco` agora tem campo `cod_municipio`
- `from_api()` extrai `ibge_id` do campo `cidade` da API cnpj.ws
- `_salvar_ini()` persiste `cod_municipio` no INI em vez de string vazia

## Mudanças

- `nfe_sync/apis/cnpjws.py`: adiciona `cod_municipio` a `CnpjwsEndereco`; extrai `cidade.ibge_id` em `from_api()`
- `nfe_sync/apis/cli.py`: salva `end.cod_municipio` no INI
- `tests/test_cnpjws.py`: 3 testes cobrindo extração do ibge_id, ausência do campo, e municipio

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)