### PR TITLE
feat: #45 — parâmetro --destinatario no comando emitir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.2.70
+- fix: #50 #51 #52 — indicador_destino, indicador_ie e CFOP automaticos por UF
+
 ## 0.2.69
 - fix: #44 — config.py carrega campos de endereco do INI
 - fix: #46 — cnpjws extrai cod_municipio do ibge_id e salva no INI

--- a/nfe_sync/commands/emissao.py
+++ b/nfe_sync/commands/emissao.py
@@ -52,12 +52,20 @@ def cmd_emitir(args):
         dest_emi = emi
         dest_end = end
 
+    # Issues #50, #51, #52: ajustar indicador_destino, indicador_ie e CFOP
+    # conforme UF do destinatário vs emitente
+    interestadual = dest_end.uf.upper() != end.uf.upper()
+    indicador_destino = 2 if interestadual else 1
+    indicador_ie = 1 if dest_emi.inscricao_estadual else 9
+    cfop = "6102" if interestadual else "5102"
+
     dados = DadosEmissao(
+        indicador_destino=indicador_destino,
         destinatario=Destinatario(
             razao_social="NF-E EMITIDA EM AMBIENTE DE HOMOLOGACAO - SEM VALOR FISCAL",
             tipo_documento="CNPJ",
             numero_documento=dest_emi.cnpj,
-            indicador_ie=1,
+            indicador_ie=indicador_ie,
             inscricao_estadual=dest_emi.inscricao_estadual,
             endereco=Endereco(
                 logradouro=dest_end.logradouro,
@@ -74,7 +82,7 @@ def cmd_emitir(args):
                 codigo="0001",
                 descricao="PRODUTO TESTE HOMOLOGACAO",
                 ncm="71131100",
-                cfop="5102",
+                cfop=cfop,
                 quantidade_comercial=Decimal("1.0000"),
                 valor_unitario_comercial=Decimal("10.00"),
                 quantidade_tributavel=Decimal("1.0000"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nfe-sync"
-version = "0.2.69"
+version = "0.2.70"
 requires-python = ">=3.12"
 dependencies = ["pynfe>=0.6.5", "python-dotenv", "pydantic>=2.0", "requests", "signxml"]
 


### PR DESCRIPTION
## Resumo

- Adiciona `--destinatario EMPRESA` opcional ao comando `emitir`
- Permite testar o fluxo E2E: SUL emite para SRNACIONAL → SRNACIONAL recebe via `consultar-nsu` → manifesta ciência
- Sem `--destinatario`, comportamento atual é preservado (usa o próprio emitente)

## Mudanças

- `commands/emissao.py`:
  - Importa `carregar_empresas` e `CONFIG_FILE`
  - Carrega empresa destinatária do config quando `--destinatario` é fornecido
  - Valida existência e presença de endereço do destinatário
  - Usa CNPJ e endereço do destinatário no `DadosEmissao`
  - `razao_social` mantém o valor obrigatório SEFAZ para homologação
- `tests/test_commands_emissao.py`: 2 testes (destinatário inexistente, destinatário sem endereço)

## Dependências

Requer que #44 e #46 estejam mergeados para funcionar corretamente (endereço precisa estar carregado do INI).

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)