### PR TITLE
fix: #53 — agora_brt() preserva tzinfo BRT (-03:00)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.2.71
+- fix: #53 — agora_brt() preserva tzinfo BRT; corrige comparacoes naive/aware
+
 ## 0.2.70
 - fix: #50 #51 #52 — indicador_destino, indicador_ie e CFOP automaticos por UF
 

--- a/nfe_sync/consulta.py
+++ b/nfe_sync/consulta.py
@@ -1,7 +1,9 @@
 import logging
 import traceback
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Callable
+
+_BRT = timezone(timedelta(hours=-3))
 
 from .models import EmpresaConfig, validar_cnpj_sefaz
 from .state import get_ultimo_nsu, set_ultimo_nsu, get_cooldown, set_cooldown, salvar_estado
@@ -42,6 +44,8 @@ def verificar_cooldown(bloqueado_ate: str | None) -> tuple[bool, str]:
         return False, ""
     try:
         dt = datetime.fromisoformat(bloqueado_ate)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=_BRT)
         agora = _agora_brt()
         if agora < dt:
             restante = dt - agora

--- a/nfe_sync/log.py
+++ b/nfe_sync/log.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from pynfe.utils import etree
 
@@ -16,7 +16,7 @@ def _limpar_logs_antigos():
     for nome in os.listdir(LOG_DIR):
         caminho = os.path.join(LOG_DIR, nome)
         if os.path.isfile(caminho):
-            modificado = datetime.fromtimestamp(os.path.getmtime(caminho))
+            modificado = datetime.fromtimestamp(os.path.getmtime(caminho), tz=timezone.utc)
             if modificado < limite:
                 # Issue #13: tratar erros de remoção individualmente
                 try:

--- a/nfe_sync/xml_utils.py
+++ b/nfe_sync/xml_utils.py
@@ -10,8 +10,8 @@ _BRT = timezone(timedelta(hours=-3))
 
 
 def agora_brt() -> datetime:
-    """Retorna o datetime atual no fuso BRT (UTC-3) sem informação de timezone."""
-    return datetime.now(_BRT).replace(tzinfo=None)
+    """Retorna o datetime atual no fuso BRT (UTC-3), com tzinfo preservado."""
+    return datetime.now(_BRT)
 
 # Seguro contra ataques XXE: sem resolucao de entidades externas ou DTD
 # Issue #3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nfe-sync"
-version = "0.2.70"
+version = "0.2.71"
 requires-python = ">=3.12"
 dependencies = ["pynfe>=0.6.5", "python-dotenv", "pydantic>=2.0", "requests", "signxml"]
 

--- a/tests/test_consulta.py
+++ b/tests/test_consulta.py
@@ -44,9 +44,13 @@ class TestVerificarCooldown:
 
 class TestCalcularProximoCooldown:
     def test_retorna_iso_futuro(self):
+        from datetime import timezone
         resultado = calcular_proximo_cooldown(60)
         dt = datetime.fromisoformat(resultado)
-        assert dt > datetime.now()
+        agora = datetime.now(timezone.utc)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        assert dt > agora
 
 
 class TestConsultarNsu:
@@ -206,11 +210,13 @@ class TestConsultarNsuCallback:
 
 
 class TestAgoraBrt:
-    """Issue #14: _agora_brt retorna datetime sem tzinfo."""
+    """Issue #53: _agora_brt retorna datetime com tzinfo BRT (-03:00)."""
 
-    def test_retorna_sem_tzinfo(self):
+    def test_retorna_com_tzinfo_brt(self):
+        from datetime import timedelta, timezone
         dt = _agora_brt()
-        assert dt.tzinfo is None
+        assert dt.tzinfo is not None
+        assert dt.utcoffset() == timedelta(hours=-3)
 
     def test_e_datetime(self):
         assert isinstance(_agora_brt(), datetime)

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -13,17 +13,19 @@ from nfe_sync.xml_utils import agora_brt as _agora_brt
 
 
 class TestAgora:
-    def test_retorna_datetime_sem_tzinfo(self):
+    def test_retorna_datetime_com_tzinfo_brt(self):
+        """Issue #53: tzinfo deve ser BRT (-03:00), não None."""
         dt = _agora_brt()
-        assert dt.tzinfo is None
+        assert dt.tzinfo is not None
+        assert dt.utcoffset() == timedelta(hours=-3)
 
     def test_aproximadamente_agora(self):
+        from datetime import timezone
         dt = _agora_brt()
-        agora_utc = datetime.utcnow()
-        # BRT é UTC-3, então deve estar cerca de 3h atrás do UTC
+        agora_utc = datetime.now(timezone.utc)
+        # BRT é UTC-3; diferença deve ser < 1 minuto
         diff = abs((agora_utc - dt).total_seconds())
-        # tolerância de 1 minuto para variações
-        assert diff < 3 * 3600 + 60
+        assert diff < 60
 
 
 class TestLimparLogsAntigos:


### PR DESCRIPTION
## Resumo

- Remove `.replace(tzinfo=None)` de `agora_brt()` — pynfe agora recebe datetime aware e gera `dhEmi` com `-03:00`
- Corrige comparações naive/aware em `consulta.py` (cooldown) e `log.py` (limpeza de logs)
- Atualiza testes que afirmavam `tzinfo is None`

## Mudanças

- `xml_utils.py`: `agora_brt()` retorna `datetime.now(_BRT)` sem `.replace(tzinfo=None)`
- `consulta.py`: adiciona `_BRT`; se `fromisoformat` retornar naive, adiciona tzinfo BRT antes de comparar
- `log.py`: `datetime.fromtimestamp(..., tz=timezone.utc)` para comparação aware/aware
- `tests/test_log.py`: atualiza `TestAgora` — tzinfo deve ser `-03:00`, não `None`
- `tests/test_consulta.py`: atualiza `TestAgoraBrt` e `TestCalcularProximoCooldown`

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)