### PR TITLE
fix: #54 — normalizar complemento no _salvar_ini e truncar a 60 chars no emitir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.2.71
 - fix: #53 — agora_brt() preserva tzinfo BRT; corrige comparacoes naive/aware
+- fix: #54 — normalizar complemento no _salvar_ini e truncar a 60 chars no emitir
 
 ## 0.2.70
 - fix: #50 #51 #52 — indicador_destino, indicador_ie e CFOP automaticos por UF

--- a/nfe_sync/apis/cli.py
+++ b/nfe_sync/apis/cli.py
@@ -1,5 +1,6 @@
 import argparse
 import configparser
+import re
 import sys
 
 from .exceptions import ApiConfigError
@@ -67,7 +68,7 @@ def _salvar_ini(empresa, nome_secao: str):
     cfg.set(nome_secao, "regime_tributario", cfg.get(nome_secao, "regime_tributario", fallback="1"))
     cfg.set(nome_secao, "logradouro", end.logradouro)
     cfg.set(nome_secao, "numero", end.numero)
-    cfg.set(nome_secao, "complemento", end.complemento or "")
+    cfg.set(nome_secao, "complemento", re.sub(r'\s+', ' ', end.complemento or "").strip())
     cfg.set(nome_secao, "bairro", end.bairro)
     cfg.set(nome_secao, "municipio", end.municipio)
     cfg.set(nome_secao, "cod_municipio", end.cod_municipio)

--- a/nfe_sync/emissao.py
+++ b/nfe_sync/emissao.py
@@ -31,7 +31,7 @@ def emitir(empresa: EmpresaConfig, serie: str, numero_nf: int, dados: DadosEmiss
         codigo_de_regime_tributario=emi.regime_tributario,
         endereco_logradouro=end.logradouro,
         endereco_numero=end.numero,
-        endereco_complemento=end.complemento,
+        endereco_complemento=end.complemento[:60],
         endereco_bairro=end.bairro,
         endereco_municipio=end.municipio,
         endereco_cod_municipio=end.cod_municipio,


### PR DESCRIPTION
## Resumo

- Complemento com espaços múltiplos (ex: saído da API cnpj.ws) é normalizado na origem via `re.sub`
- Defesa adicional: `emissao.py` trunca a 60 chars antes de passar ao pynfe
- Previne cStat=225 (Rejeição: Falha no Schema XML — xCpl excede limite)

## Mudanças

- `apis/cli.py`: `re.sub(r'\s+', ' ', ...).strip()` no complemento antes de salvar no INI
- `emissao.py`: `end.complemento[:60]` na serialização do emitente
- `tests/test_cnpjws.py`: 2 testes em `TestSalvarIniComplemento` (limpeza e vazio)
- `tests/test_emitir.py`: `TestComplementoTruncado` verifica que pynfe recebe ≤ 60 chars

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)