### PR TITLE
fix: #57 — NSU e numeração NF separados por ambiente no state.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.2.72
+- fix: #57 — NSU e numeracao NF separados por ambiente no state.json
+
 ## 0.2.71
 - fix: #53 — agora_brt() preserva tzinfo BRT; corrige comparacoes naive/aware
 - fix: #54 — normalizar complemento no _salvar_ini e truncar a 60 chars no emitir

--- a/nfe_sync/commands/consulta.py
+++ b/nfe_sync/commands/consulta.py
@@ -102,7 +102,8 @@ def cmd_consultar_nsu(args):
     nsu = args.nsu
 
     if args.zerar_nsu:
-        set_ultimo_nsu(estado, cnpj, 0)
+        ambiente = "homologacao" if empresa.homologacao else "producao"
+        set_ultimo_nsu(estado, cnpj, 0, ambiente)
         salvar_estado(STATE_FILE, estado)
         nsu = 0
         print(f"NSU zerado para {cnpj}.")

--- a/nfe_sync/commands/emissao.py
+++ b/nfe_sync/commands/emissao.py
@@ -15,8 +15,9 @@ def cmd_emitir(args):
     empresa, estado = _carregar(args)
     cnpj = empresa.emitente.cnpj
     serie = args.serie
+    ambiente = "homologacao" if empresa.homologacao else "producao"
 
-    ultimo = get_ultimo_numero_nf(estado, cnpj, serie)
+    ultimo = get_ultimo_numero_nf(estado, cnpj, serie, ambiente)
     numero_nf = ultimo + 1
 
     print(f"Empresa: {empresa.nome} (CNPJ {cnpj})")
@@ -112,7 +113,7 @@ def cmd_emitir(args):
         print(f"Chave: {resultado.chave}")
         print(f"XML salvo em: {arquivo}")
 
-        set_ultimo_numero_nf(estado, cnpj, serie, numero_nf)
+        set_ultimo_numero_nf(estado, cnpj, serie, numero_nf, ambiente)
         salvar_estado(STATE_FILE, estado)
         print(f"Numero NF {numero_nf} serie {serie} salvo em {STATE_FILE}")
     else:

--- a/nfe_sync/consulta.py
+++ b/nfe_sync/consulta.py
@@ -207,7 +207,7 @@ def consultar_nsu(
         )
 
     if nsu is None:
-        nsu = get_ultimo_nsu(estado, cnpj)
+        nsu = get_ultimo_nsu(estado, cnpj, ambiente)
 
     con = criar_comunicacao(empresa)
 
@@ -244,7 +244,7 @@ def consultar_nsu(
         docs = _processar_docs(xml_resp)
         documentos.extend(docs)
 
-        set_ultimo_nsu(estado, cnpj, ult_nsu)
+        set_ultimo_nsu(estado, cnpj, ult_nsu, ambiente)
         # Issue #7: salvar estado a cada _SALVAR_A_CADA páginas ou na última
         if pagina % _SALVAR_A_CADA == 0 or ult_nsu >= max_nsu:
             if state_file:

--- a/nfe_sync/state.py
+++ b/nfe_sync/state.py
@@ -26,13 +26,14 @@ def salvar_estado(state_file: str, estado: dict) -> None:
             fcntl.flock(f, fcntl.LOCK_UN)
 
 
-def get_ultimo_numero_nf(estado: dict, cnpj: str, serie: str) -> int:
-    chave = f"{cnpj}:{serie}"
-    return estado.get("numeracao", {}).get(chave, 0)
+def get_ultimo_numero_nf(estado: dict, cnpj: str, serie: str, ambiente: str = "producao") -> int:
+    num = estado.get("numeracao", {})
+    # Tenta chave nova (cnpj:serie:ambiente), fallback para chave legada (cnpj:serie)
+    return num.get(f"{cnpj}:{serie}:{ambiente}", num.get(f"{cnpj}:{serie}", 0))
 
 
-def set_ultimo_numero_nf(estado: dict, cnpj: str, serie: str, numero: int) -> None:
-    estado.setdefault("numeracao", {})[f"{cnpj}:{serie}"] = numero
+def set_ultimo_numero_nf(estado: dict, cnpj: str, serie: str, numero: int, ambiente: str = "producao") -> None:
+    estado.setdefault("numeracao", {})[f"{cnpj}:{serie}:{ambiente}"] = numero
 
 
 def _chave_cooldown(cnpj: str, ambiente: str) -> str:
@@ -52,9 +53,11 @@ def limpar_cooldown(estado: dict, cnpj: str, ambiente: str = "homologacao") -> N
     cooldowns.pop(_chave_cooldown(cnpj, ambiente), None)
 
 
-def get_ultimo_nsu(estado: dict, cnpj: str) -> int:
-    return estado.get("nsu", {}).get(cnpj, 0)
+def get_ultimo_nsu(estado: dict, cnpj: str, ambiente: str = "producao") -> int:
+    nsu_dict = estado.get("nsu", {})
+    # Tenta chave nova (cnpj:ambiente), fallback para chave legada (cnpj)
+    return nsu_dict.get(f"{cnpj}:{ambiente}", nsu_dict.get(cnpj, 0))
 
 
-def set_ultimo_nsu(estado: dict, cnpj: str, nsu: int) -> None:
-    estado.setdefault("nsu", {})[cnpj] = nsu
+def set_ultimo_nsu(estado: dict, cnpj: str, nsu: int, ambiente: str = "producao") -> None:
+    estado.setdefault("nsu", {})[f"{cnpj}:{ambiente}"] = nsu

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nfe-sync"
-version = "0.2.71"
+version = "0.2.72"
 requires-python = ">=3.12"
 dependencies = ["pynfe>=0.6.5", "python-dotenv", "pydantic>=2.0", "requests", "signxml"]
 

--- a/tests/test_consulta.py
+++ b/tests/test_consulta.py
@@ -134,8 +134,9 @@ class TestConsultarNsu:
 
         # verifica que salvou estado (sem cooldown quando baixou documentos com 138)
         estado_salvo = carregar_estado(state_file)
-        assert estado_salvo["nsu"][empresa_sul.emitente.cnpj] == 100
-        assert f"{empresa_sul.emitente.cnpj}:homologacao" not in estado_salvo.get("cooldown", {})
+        cnpj = empresa_sul.emitente.cnpj
+        assert estado_salvo["nsu"][f"{cnpj}:homologacao"] == 100  # Issue #57: chave inclui ambiente
+        assert f"{cnpj}:homologacao" not in estado_salvo.get("cooldown", {})
 
     @patch("nfe_sync.xml_utils.ComunicacaoSefaz")
     def test_usa_ultimo_nsu_do_estado(self, mock_sefaz_cls, empresa_sul, tmp_path):

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -81,6 +81,24 @@ class TestNumeracao:
         assert get_ultimo_numero_nf(estado, "123", "1") == 5
         assert get_ultimo_numero_nf(estado, "123", "2") == 12
 
+    def test_ambientes_independentes(self):
+        """Issue #57: homologacao e producao devem ter numeracoes separadas."""
+        estado = {}
+        set_ultimo_numero_nf(estado, "123", "1", 3, "homologacao")
+        set_ultimo_numero_nf(estado, "123", "1", 10, "producao")
+        assert get_ultimo_numero_nf(estado, "123", "1", "homologacao") == 3
+        assert get_ultimo_numero_nf(estado, "123", "1", "producao") == 10
+
+    def test_fallback_chave_legada(self):
+        """Issue #57: migração — chave antiga (cnpj:serie) usada como fallback."""
+        estado = {"numeracao": {"123:1": 7}}
+        assert get_ultimo_numero_nf(estado, "123", "1", "producao") == 7
+
+    def test_chave_nova_tem_prioridade_sobre_legada(self):
+        """Issue #57: chave nova (cnpj:serie:ambiente) prevalece sobre legada."""
+        estado = {"numeracao": {"123:1": 7, "123:1:producao": 15}}
+        assert get_ultimo_numero_nf(estado, "123", "1", "producao") == 15
+
 
 class TestCooldown:
     def test_get_inexistente(self):
@@ -131,3 +149,21 @@ class TestNsu:
         set_ultimo_nsu(estado, "222", 20)
         assert get_ultimo_nsu(estado, "111") == 10
         assert get_ultimo_nsu(estado, "222") == 20
+
+    def test_ambientes_independentes(self):
+        """Issue #57: homologacao e producao devem ter NSUs separados."""
+        estado = {}
+        set_ultimo_nsu(estado, "123", 100, "homologacao")
+        set_ultimo_nsu(estado, "123", 4059, "producao")
+        assert get_ultimo_nsu(estado, "123", "homologacao") == 100
+        assert get_ultimo_nsu(estado, "123", "producao") == 4059
+
+    def test_fallback_chave_legada(self):
+        """Issue #57: migração — chave antiga (cnpj) usada como fallback."""
+        estado = {"nsu": {"123": 4059}}
+        assert get_ultimo_nsu(estado, "123", "producao") == 4059
+
+    def test_chave_nova_tem_prioridade_sobre_legada(self):
+        """Issue #57: chave nova (cnpj:ambiente) prevalece sobre legada."""
+        estado = {"nsu": {"123": 4059, "123:producao": 5000}}
+        assert get_ultimo_nsu(estado, "123", "producao") == 5000


### PR DESCRIPTION
## Resumo

NSU e numeração de NF agora usam chaves `cnpj:ambiente` e `cnpj:serie:ambiente` no `.state.json`, consistente com o padrão já usado pelo cooldown. Inclui fallback para chaves legadas (migração transparente).

## Mudanças

**`state.py`**
- `get/set_ultimo_nsu`: nova assinatura `(estado, cnpj, nsu, ambiente="producao")` — chave `cnpj:ambiente`
- `get/set_ultimo_numero_nf`: nova assinatura `(estado, cnpj, serie, numero, ambiente="producao")` — chave `cnpj:serie:ambiente`
- Ambos com fallback para chaves legadas (sem ambiente) para migração transparente

**Callers atualizados**
- `consulta.py`: passa `ambiente` para `get/set_ultimo_nsu`
- `commands/consulta.py`: passa `ambiente` para `set_ultimo_nsu` (--zerar-nsu)
- `commands/emissao.py`: passa `ambiente` para `get/set_ultimo_numero_nf`

**Testes**
- `test_state.py`: 6 novos testes (ambientes independentes, fallback legado, prioridade nova chave) para NSU e numeração
- `test_consulta.py`: atualiza verificação de chave salva no state

## Migração

`.state.json` existentes continuam funcionando — `get_ultimo_nsu` e `get_ultimo_numero_nf` fazem fallback para a chave legada se a nova não existir. Na próxima escrita, a chave nova é criada automaticamente.

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)