### PR TITLE
fix: #64 #65 #66 — corrigir testes E2E homologacao/marker/duplicidade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.2.77
+- fix: #64 #65 #66 — homologacao forcado em run_nfe, marker slow via pytest_configure, fixture nf_emitida session-scoped
+
 ## 0.2.76
 - fix: #63 — reduzir timeout padrao de run_nfe para 30s
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nfe-sync"
-version = "0.2.76"
+version = "0.2.77"
 requires-python = ">=3.12"
 dependencies = ["pynfe>=0.6.5", "python-dotenv", "pydantic>=2.0", "requests", "signxml"]
 


### PR DESCRIPTION
## Problema
Três bugs críticos nos testes E2E introduzidos no PR #60:

- **#64**: `run_nfe()` não passava `--homologacao` — testes `@slow` emitiam NF-e em **produção**
- **#65**: marker `slow` gerava `PytestUnknownMarkWarning` quando pytest rodava fora do diretório do pacote
- **#66**: `backup_state` restaurava contador local após emissão bem-sucedida — próximos testes recebiam cStat=539 (duplicidade na SEFAZ)

## Solução

**#64** — `run_nfe()` agora tem `homologacao=True` por padrão, injetando `--homologacao` antes do subcomando. Impossível rodar em produção por acidente.

**#65** — Adicionado `pytest_configure` no `conftest.py` que registra o marker via `config.addinivalue_line`, independente de onde o pytest é executado.

**#66** — Removido `backup_state` dos testes de emissão. Criada fixture `nf_emitida` com `scope="session"`: emite uma única NF-e e compartilha chave/número entre todos os testes que dependem dela — sem duplicidade.

## Verificação
```
pytest tests/ -m "not slow" -v   # 207 passed, 1 skipped
pytest tests/e2e/ -m slow --collect-only  # 6 collected, sem warnings
```

Closes #64
Closes #65
Closes #66