### PR TITLE
fix: #68 #69 — fallback NSU/numeracao retorna 0; test_incrementa_numero autonomo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.2.78
+- fix: #68 #69 — fallback NSU/numeracao retorna 0 sem herdar chave legada; test_incrementa_numero autonomo
+
 ## 0.2.77
 - fix: #64 #65 #66 — homologacao forcado em run_nfe, marker slow via pytest_configure, fixture nf_emitida session-scoped
 

--- a/nfe_sync/state.py
+++ b/nfe_sync/state.py
@@ -27,9 +27,7 @@ def salvar_estado(state_file: str, estado: dict) -> None:
 
 
 def get_ultimo_numero_nf(estado: dict, cnpj: str, serie: str, ambiente: str = "producao") -> int:
-    num = estado.get("numeracao", {})
-    # Tenta chave nova (cnpj:serie:ambiente), fallback para chave legada (cnpj:serie)
-    return num.get(f"{cnpj}:{serie}:{ambiente}", num.get(f"{cnpj}:{serie}", 0))
+    return estado.get("numeracao", {}).get(f"{cnpj}:{serie}:{ambiente}", 0)
 
 
 def set_ultimo_numero_nf(estado: dict, cnpj: str, serie: str, numero: int, ambiente: str = "producao") -> None:
@@ -54,9 +52,7 @@ def limpar_cooldown(estado: dict, cnpj: str, ambiente: str = "homologacao") -> N
 
 
 def get_ultimo_nsu(estado: dict, cnpj: str, ambiente: str = "producao") -> int:
-    nsu_dict = estado.get("nsu", {})
-    # Tenta chave nova (cnpj:ambiente), fallback para chave legada (cnpj)
-    return nsu_dict.get(f"{cnpj}:{ambiente}", nsu_dict.get(cnpj, 0))
+    return estado.get("nsu", {}).get(f"{cnpj}:{ambiente}", 0)
 
 
 def set_ultimo_nsu(estado: dict, cnpj: str, nsu: int, ambiente: str = "producao") -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nfe-sync"
-version = "0.2.77"
+version = "0.2.78"
 requires-python = ">=3.12"
 dependencies = ["pynfe>=0.6.5", "python-dotenv", "pydantic>=2.0", "requests", "signxml"]
 

--- a/tests/e2e/test_e2e_homolog.py
+++ b/tests/e2e/test_e2e_homolog.py
@@ -47,15 +47,18 @@ class TestEmitirHomologacao:
         assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"
         assert "Status:" in result.stdout
 
-    def test_emitir_incrementa_numero(self, emitente, serie, nf_emitida):
-        _, numero_anterior = nf_emitida
+    def test_emitir_incrementa_numero(self, emitente, serie):
+        result1 = run_nfe("emitir", emitente, "--serie", serie)
+        assert result1.returncode == 0, result1.stdout
+        match1 = re.search(r"Numero NF (\d+) serie", result1.stdout)
+        assert match1
 
-        result = run_nfe("emitir", emitente, "--serie", serie)
-        assert result.returncode == 0, result.stdout
+        result2 = run_nfe("emitir", emitente, "--serie", serie)
+        assert result2.returncode == 0, result2.stdout
+        match2 = re.search(r"Numero NF (\d+) serie", result2.stdout)
+        assert match2
 
-        match = re.search(r"Numero NF (\d+) serie", result.stdout)
-        assert match
-        assert int(match.group(1)) == numero_anterior + 1
+        assert int(match2.group(1)) == int(match1.group(1)) + 1
 
 
 @pytest.mark.slow

--- a/tests/test_consulta.py
+++ b/tests/test_consulta.py
@@ -146,7 +146,7 @@ class TestConsultarNsu:
 
         state_file = str(tmp_path / "state.json")
         cnpj = empresa_sul.emitente.cnpj
-        estado = {"nsu": {cnpj: 50}}
+        estado = {"nsu": {f"{cnpj}:homologacao": 50}}
 
         consultar_nsu(empresa_sul, estado, state_file)
         mock_sefaz_cls.return_value.consulta_distribuicao.assert_called_once_with(

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -89,10 +89,10 @@ class TestNumeracao:
         assert get_ultimo_numero_nf(estado, "123", "1", "homologacao") == 3
         assert get_ultimo_numero_nf(estado, "123", "1", "producao") == 10
 
-    def test_fallback_chave_legada(self):
-        """Issue #57: migração — chave antiga (cnpj:serie) usada como fallback."""
+    def test_chave_legada_sem_ambiente_retorna_zero(self):
+        """Issue #68: chave legada (cnpj:serie) sem ambiente retorna 0 — nao herda valor de outro ambiente."""
         estado = {"numeracao": {"123:1": 7}}
-        assert get_ultimo_numero_nf(estado, "123", "1", "producao") == 7
+        assert get_ultimo_numero_nf(estado, "123", "1", "producao") == 0
 
     def test_chave_nova_tem_prioridade_sobre_legada(self):
         """Issue #57: chave nova (cnpj:serie:ambiente) prevalece sobre legada."""
@@ -158,10 +158,10 @@ class TestNsu:
         assert get_ultimo_nsu(estado, "123", "homologacao") == 100
         assert get_ultimo_nsu(estado, "123", "producao") == 4059
 
-    def test_fallback_chave_legada(self):
-        """Issue #57: migração — chave antiga (cnpj) usada como fallback."""
+    def test_chave_legada_sem_ambiente_retorna_zero(self):
+        """Issue #68: chave legada (cnpj) sem ambiente retorna 0 — nao herda valor de outro ambiente."""
         estado = {"nsu": {"123": 4059}}
-        assert get_ultimo_nsu(estado, "123", "producao") == 4059
+        assert get_ultimo_nsu(estado, "123", "producao") == 0
 
     def test_chave_nova_tem_prioridade_sobre_legada(self):
         """Issue #57: chave nova (cnpj:ambiente) prevalece sobre legada."""


### PR DESCRIPTION
## Problema

**#68** — `get_ultimo_nsu()` e `get_ultimo_numero_nf()` faziam fallback para chaves legadas (sem `:ambiente`), herdando valores de produção em consultas de homologação. Ex: NSU 5340 de produção sendo usado no ambiente de homologação → SEFAZ rejeita.

**#69** — `test_emitir_incrementa_numero` dependia da fixture `nf_emitida` para obter o número anterior. Outros testes emitindo NF-e entre a fixture e o teste avançavam o contador, quebrando a comparação.

## Solução

**#68** — Removido o fallback para chave legada em `state.py`. Se `cnpj:ambiente` não existe, retorna 0. A chave legada (sem ambiente) é ignorada.

```python
# antes
return nsu_dict.get(f"{cnpj}:{ambiente}", nsu_dict.get(cnpj, 0))
# depois
return estado.get("nsu", {}).get(f"{cnpj}:{ambiente}", 0)
```

**#69** — Teste emite duas NF-e consecutivas no próprio corpo e verifica que a segunda = primeira + 1. Sem dependência de fixtures nem de estado externo.

## Testes
- `TestNsu::test_chave_legada_sem_ambiente_retorna_zero` — substitui `test_fallback_chave_legada`
- `TestNumeracao::test_chave_legada_sem_ambiente_retorna_zero` — idem
- `test_consulta.py::test_usa_ultimo_nsu_do_estado` — atualizado para usar chave `cnpj:homologacao`

## Verificação
```
pytest tests/ -m "not slow" -v  # 207 passed, 1 skipped
```

Closes #68
Closes #69