### PR TITLE
fix: #71 #72 — imprimir status/motivo antes de exit; tolerar cStat=656 no E2E

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.2.79
+- fix: #71 #72 — imprimir status/motivo antes de exit em consultar-nsu; tolerar cStat=656 no E2E
+
 ## 0.2.78
 - fix: #68 #69 — fallback NSU/numeracao retorna 0 sem herdar chave legada; test_incrementa_numero autonomo
 

--- a/nfe_sync/commands/consulta.py
+++ b/nfe_sync/commands/consulta.py
@@ -143,6 +143,10 @@ def cmd_consultar_nsu(args):
         sys.exit(1)
 
     if not resultado.sucesso:
+        if resultado.status:
+            print(f"Status: {resultado.status}")
+        if resultado.motivo:
+            print(f"Motivo: {resultado.motivo}")
         sys.exit(1)
 
     print(f"Status: {resultado.status}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nfe-sync"
-version = "0.2.78"
+version = "0.2.79"
 requires-python = ">=3.12"
 dependencies = ["pynfe>=0.6.5", "python-dotenv", "pydantic>=2.0", "requests", "signxml"]
 

--- a/tests/e2e/test_e2e_homolog.py
+++ b/tests/e2e/test_e2e_homolog.py
@@ -66,6 +66,10 @@ class TestConsultarNsuHomologacao:
     def test_consultar_nsu_executa_sem_erro(self, emitente):
         result = run_nfe("consultar-nsu", emitente)
 
+        # 656 = consumo indevido (rate limit SEFAZ) — não é erro do CLI
+        if "656" in result.stdout:
+            pytest.skip("SEFAZ rate limit (cStat=656) — tente novamente apos 1 hora")
+
         # status 137 = nenhum documento localizado, 138 = documentos encontrados
         # ambos são sucesso (returncode 0)
         assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"
@@ -73,6 +77,10 @@ class TestConsultarNsuHomologacao:
 
     def test_consultar_nsu_zerar_executa(self, emitente, backup_state):
         result = run_nfe("consultar-nsu", emitente, "--zerar-nsu")
+
+        # 656 = consumo indevido (rate limit SEFAZ) — não é erro do CLI
+        if "656" in result.stdout:
+            pytest.skip("SEFAZ rate limit (cStat=656) — tente novamente apos 1 hora")
 
         assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"
         assert "NSU zerado" in result.stdout


### PR DESCRIPTION
## Problema

**#71** — `cmd_consultar_nsu` fazia `sys.exit(1)` silencioso quando `sucesso=False` com `status` não-nulo (ex: cStat=656). O usuário via o cabeçalho da consulta e nada mais, sem saber o motivo da falha.

**#72** — `test_consultar_nsu_executa_sem_erro` assumia `returncode == 0`, mas cStat=656 (consumo indevido / rate limit da SEFAZ) resulta em exit 1. Isso acontece frequentemente em homologação após muitas execuções. Depende do #71 para que o "656" apareça no stdout.

## Solução

**#71** — Antes do `sys.exit(1)` por falha, imprime status e motivo se disponíveis:

```python
if not resultado.sucesso:
    if resultado.status:
        print(f"Status: {resultado.status}")
    if resultado.motivo:
        print(f"Motivo: {resultado.motivo}")
    sys.exit(1)
```

**#72** — Testes verificam `"656" in result.stdout` e chamam `pytest.skip()` quando rate limit detectado. A verificação funciona porque o #71 agora garante que o status aparece no stdout.

## Testes
- `TestCmdConsultarExitCode::test_nsu_erro_imprime_status_antes_de_sair` — verifica exit 1 com "656" e motivo no stdout

## Verificação
```
pytest tests/ -m "not slow" -v  # 208 passed, 1 skipped
```

Closes #71
Closes #72