### PR TITLE
feat: cancelamento de NF-e via SEFAZ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.2.80
+- feat: cancelamento de NF-e via SEFAZ (EventoCancelarNota)
+
 ## 0.2.79
 - fix: #71 #72 — imprimir status/motivo antes de exit em consultar-nsu; tolerar cStat=656 no E2E
 

--- a/nfe_sync/cancelamento.py
+++ b/nfe_sync/cancelamento.py
@@ -1,0 +1,51 @@
+from pynfe.entidades.fonte_dados import FonteDados
+from pynfe.entidades.evento import EventoCancelarNota
+from pynfe.processamento.serializacao import SerializacaoXML
+from pynfe.processamento.assinatura import AssinaturaA1
+
+from .models import EmpresaConfig, validar_cnpj_sefaz
+from .exceptions import NfeValidationError
+from .xml_utils import extract_status_motivo, agora_brt, chamar_sefaz
+from .results import ResultadoCancelamento
+
+NS = {"ns": "http://www.portalfiscal.inf.br/nfe"}
+
+
+def cancelar(
+    empresa: EmpresaConfig,
+    chave: str,
+    protocolo: str,
+    justificativa: str,
+) -> ResultadoCancelamento:
+    if len(chave) != 44 or not chave.isdigit():
+        raise NfeValidationError(f"[{empresa.nome}] Chave deve ter 44 digitos.")
+    if len(justificativa) < 15:
+        raise NfeValidationError(f"[{empresa.nome}] Justificativa minimo 15 chars.")
+    validar_cnpj_sefaz(empresa.emitente.cnpj, empresa.nome)
+
+    fonte = FonteDados()
+    evento = EventoCancelarNota(
+        _fonte_dados=fonte,
+        cnpj=empresa.emitente.cnpj,
+        chave=chave,
+        data_emissao=agora_brt(),
+        uf="AN",
+        protocolo=protocolo,
+        justificativa=justificativa,
+        n_seq_evento=1,
+    )
+
+    xml_evento = SerializacaoXML(fonte, homologacao=empresa.homologacao).serializar_evento(evento)
+    xml_assinado = AssinaturaA1(empresa.certificado.path, empresa.certificado.senha).assinar(xml_evento)
+
+    xml_resp, xml_resp_str = chamar_sefaz(empresa, "evento", modelo="nfe", evento=xml_assinado)
+    resultados = extract_status_motivo(xml_resp, NS)
+    protocolos = xml_resp.xpath("//ns:nProt", namespaces=NS)
+
+    return ResultadoCancelamento(
+        sucesso=any(r["status"] in ("135", "136") for r in resultados),
+        resultados=resultados,
+        protocolo=protocolos[0].text if protocolos else None,
+        xml=xml_resp_str,
+        xml_resposta=xml_resp_str,
+    )

--- a/nfe_sync/cli.py
+++ b/nfe_sync/cli.py
@@ -9,6 +9,7 @@ from .commands.consulta import ConsultaBlueprint
 from .commands.manifestacao import ManifestacaoBlueprint
 from .commands.inutilizacao import InutilizacaoBlueprint
 from .commands.emissao import EmissaoBlueprint
+from .commands.cancelamento import CancelamentoBlueprint
 from .commands.sistema import SistemaBlueprint
 
 BLUEPRINTS = [
@@ -16,6 +17,7 @@ BLUEPRINTS = [
     ManifestacaoBlueprint(),
     InutilizacaoBlueprint(),
     EmissaoBlueprint(),
+    CancelamentoBlueprint(),
     SistemaBlueprint(),
 ]
 
@@ -41,6 +43,7 @@ def cli(argv=None):
             "  manifestar      Manifestar ciencia, confirmacao, desconhecimento ou nao-realizacao\n"
             "  inutilizar      Inutilizar faixa de numeracao de NF-e\n"
             "  emitir          Emitir NF-e de teste em homologacao\n"
+            "  cancelar        Cancela uma NF-e emitida na SEFAZ\n"
             "\n"
             "Sistema:\n"
             "  versao          Verificar versao instalada e atualizacoes disponiveis\n"
@@ -55,6 +58,7 @@ def cli(argv=None):
             "  nfe-sync manifestar     EMPRESA ciencia CHAVE\n"
             "  nfe-sync inutilizar     EMPRESA --serie 1 --inicio 5 --fim 8 --justificativa 'Motivo'\n"
             "  nfe-sync emitir         EMPRESA --serie 1\n"
+            "  nfe-sync cancelar       EMPRESA CHAVE --protocolo 135XXX --justificativa 'Motivo'\n"
         ),
     )
     amb = parser.add_mutually_exclusive_group()

--- a/nfe_sync/commands/cancelamento.py
+++ b/nfe_sync/commands/cancelamento.py
@@ -1,0 +1,49 @@
+import argparse
+import sys
+
+from . import CliBlueprint, _carregar, _salvar_log_xml, _salvar_xml
+
+
+def cmd_cancelar(args):
+    empresa, _ = _carregar(args)
+    cnpj = empresa.emitente.cnpj
+
+    print(f"Empresa: {empresa.nome} (CNPJ {cnpj})")
+    print(f"Ambiente: {'Homologacao' if empresa.homologacao else 'Producao'}")
+    print(f"Chave: {args.chave}")
+    print(f"Protocolo: {args.protocolo}")
+    print()
+
+    from ..cancelamento import cancelar
+    resultado = cancelar(empresa, args.chave, args.protocolo, args.justificativa)
+
+    _salvar_log_xml(resultado.xml_resposta, "cancelamento", args.chave)
+    arquivo = _salvar_xml(cnpj, f"{args.chave}-cancelamento.xml", resultado.xml)
+
+    print("=== RESULTADO ===")
+    for r in resultado.resultados:
+        print(f"  cStat={r['status']}  {r['motivo']}")
+    if resultado.protocolo:
+        print(f"  Protocolo: {resultado.protocolo}")
+    print(f"  XML salvo em: {arquivo}")
+
+    if not resultado.sucesso:
+        sys.exit(1)
+
+
+class CancelamentoBlueprint(CliBlueprint):
+    def register(self, subparsers, parser, amb_parent=None) -> None:
+        parents = [amb_parent] if amb_parent else []
+        p = subparsers.add_parser(
+            "cancelar",
+            parents=parents,
+            help=argparse.SUPPRESS,
+            description="Cancela uma NF-e emitida na SEFAZ.",
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+            epilog="Exemplo:\n  nfe-sync cancelar EMPRESA CHAVE --protocolo 135XXX --justificativa 'Motivo'",
+        )
+        p.add_argument("empresa", help="Nome da empresa (secao no nfe-sync.conf.ini)")
+        p.add_argument("chave", help="Chave de acesso com 44 digitos")
+        p.add_argument("--protocolo", required=True, help="Protocolo de autorizacao da NF-e")
+        p.add_argument("--justificativa", required=True, help="Motivo do cancelamento (minimo 15 caracteres)")
+        p.set_defaults(func=cmd_cancelar)

--- a/nfe_sync/results.py
+++ b/nfe_sync/results.py
@@ -67,3 +67,12 @@ class ResultadoInutilizacao:
     protocolo: str | None
     xml: str
     xml_resposta: str
+
+
+@dataclass(frozen=True, slots=True)
+class ResultadoCancelamento:
+    sucesso: bool        # True se cStat in ("135", "136")
+    resultados: list     # list[dict] de extract_status_motivo
+    protocolo: str | None
+    xml: str
+    xml_resposta: str

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nfe-sync"
-version = "0.2.79"
+version = "0.2.80"
 requires-python = ">=3.12"
 dependencies = ["pynfe>=0.6.5", "python-dotenv", "pydantic>=2.0", "requests", "signxml"]
 

--- a/tests/test_cancelamento.py
+++ b/tests/test_cancelamento.py
@@ -1,0 +1,99 @@
+import pytest
+from unittest.mock import patch
+from pynfe.utils import etree
+
+from nfe_sync.cancelamento import cancelar
+from nfe_sync.exceptions import NfeValidationError
+from nfe_sync.results import ResultadoCancelamento
+
+
+CHAVE_VALIDA = "52991299999999999999550010000000011000000010"
+PROTOCOLO_VALIDO = "135240000012345"
+JUSTIFICATIVA_VALIDA = "Erro de emissao no sistema"
+
+
+class TestCancelarValidacao:
+    def test_chave_invalida(self, empresa_sul):
+        with pytest.raises(NfeValidationError, match="44 digitos"):
+            cancelar(empresa_sul, "123", PROTOCOLO_VALIDO, JUSTIFICATIVA_VALIDA)
+
+    def test_chave_nao_numerica(self, empresa_sul):
+        chave_letras = "A" * 44
+        with pytest.raises(NfeValidationError, match="44 digitos"):
+            cancelar(empresa_sul, chave_letras, PROTOCOLO_VALIDO, JUSTIFICATIVA_VALIDA)
+
+    def test_justificativa_curta(self, empresa_sul):
+        with pytest.raises(NfeValidationError, match="15 chars"):
+            cancelar(empresa_sul, CHAVE_VALIDA, PROTOCOLO_VALIDO, "curta")
+
+
+def _patch_pynfe(chamar_sefaz_return):
+    """Context manager que mocka os componentes pynfe para não precisar de certificado real."""
+    return (
+        patch("nfe_sync.cancelamento.SerializacaoXML"),
+        patch("nfe_sync.cancelamento.AssinaturaA1"),
+        patch("nfe_sync.cancelamento.chamar_sefaz", return_value=chamar_sefaz_return),
+    )
+
+
+class TestCancelarSefaz:
+    def test_cancelar_sucesso(self, empresa_sul):
+        xml_bytes = (
+            b'<?xml version="1.0"?>'
+            b'<retEnvEvento xmlns="http://www.portalfiscal.inf.br/nfe">'
+            b'<retEvento><infEvento>'
+            b'<cStat>135</cStat>'
+            b'<xMotivo>Evento registrado e vinculado a NF-e</xMotivo>'
+            b'<nProt>135240000012345</nProt>'
+            b'</infEvento></retEvento>'
+            b'</retEnvEvento>'
+        )
+        xml_el = etree.fromstring(xml_bytes)
+        p_serial, p_assin, p_sefaz = _patch_pynfe((xml_el, xml_bytes.decode()))
+
+        with p_serial, p_assin, p_sefaz:
+            resultado = cancelar(empresa_sul, CHAVE_VALIDA, PROTOCOLO_VALIDO, JUSTIFICATIVA_VALIDA)
+
+        assert isinstance(resultado, ResultadoCancelamento)
+        assert resultado.sucesso is True
+        assert resultado.protocolo == "135240000012345"
+
+    def test_cancelar_falha(self, empresa_sul):
+        xml_bytes = (
+            b'<?xml version="1.0"?>'
+            b'<retEnvEvento xmlns="http://www.portalfiscal.inf.br/nfe">'
+            b'<retEvento><infEvento>'
+            b'<cStat>589</cStat>'
+            b'<xMotivo>Rejeicao: Duplicidade de evento</xMotivo>'
+            b'</infEvento></retEvento>'
+            b'</retEnvEvento>'
+        )
+        xml_el = etree.fromstring(xml_bytes)
+        p_serial, p_assin, p_sefaz = _patch_pynfe((xml_el, xml_bytes.decode()))
+
+        with p_serial, p_assin, p_sefaz:
+            resultado = cancelar(empresa_sul, CHAVE_VALIDA, PROTOCOLO_VALIDO, JUSTIFICATIVA_VALIDA)
+
+        assert isinstance(resultado, ResultadoCancelamento)
+        assert resultado.sucesso is False
+        assert resultado.protocolo is None
+
+    def test_cancelar_sucesso_cstat_136(self, empresa_sul):
+        """cStat=136 (cancelamento homologado) também é sucesso."""
+        xml_bytes = (
+            b'<?xml version="1.0"?>'
+            b'<retEnvEvento xmlns="http://www.portalfiscal.inf.br/nfe">'
+            b'<retEvento><infEvento>'
+            b'<cStat>136</cStat>'
+            b'<xMotivo>Evento registrado e vinculado a NF-e</xMotivo>'
+            b'<nProt>135240000099999</nProt>'
+            b'</infEvento></retEvento>'
+            b'</retEnvEvento>'
+        )
+        xml_el = etree.fromstring(xml_bytes)
+        p_serial, p_assin, p_sefaz = _patch_pynfe((xml_el, xml_bytes.decode()))
+
+        with p_serial, p_assin, p_sefaz:
+            resultado = cancelar(empresa_sul, CHAVE_VALIDA, PROTOCOLO_VALIDO, JUSTIFICATIVA_VALIDA)
+
+        assert resultado.sucesso is True

--- a/tests/test_commands_cancelamento.py
+++ b/tests/test_commands_cancelamento.py
@@ -1,0 +1,86 @@
+"""Testes para commands/cancelamento.py."""
+import pytest
+from unittest.mock import patch, MagicMock
+
+from nfe_sync.results import ResultadoCancelamento
+
+
+CHAVE_VALIDA = "52991299999999999999550010000000011000000010"
+
+
+def _make_resultado(sucesso, c_stat, motivo):
+    return ResultadoCancelamento(
+        sucesso=sucesso,
+        resultados=[{"status": c_stat, "motivo": motivo}],
+        protocolo="135240000012345" if sucesso else None,
+        xml="<cancNFe/>",
+        xml_resposta="<retEnvEvento/>",
+    )
+
+
+def _make_args(empresa):
+    args = MagicMock()
+    args.empresa = empresa.nome
+    args.chave = CHAVE_VALIDA
+    args.protocolo = "135240000012345"
+    args.justificativa = "Erro de emissao no sistema"
+    args.homologacao = True
+    args.producao = False
+    return args
+
+
+class TestCmdCancelar:
+    def test_cancelar_sucesso_salva_xml(self, empresa_sul, capsys):
+        from nfe_sync.commands.cancelamento import cmd_cancelar
+
+        resultado = _make_resultado(True, "135", "Evento registrado e vinculado a NF-e")
+        args = _make_args(empresa_sul)
+        arquivo_salvo = f"downloads/{empresa_sul.emitente.cnpj}/{CHAVE_VALIDA}-cancelamento.xml"
+
+        with patch("nfe_sync.commands.cancelamento._carregar", return_value=(empresa_sul, {})), \
+             patch("nfe_sync.cancelamento.cancelar", return_value=resultado), \
+             patch("nfe_sync.commands.cancelamento._salvar_log_xml"), \
+             patch("nfe_sync.commands.cancelamento._salvar_xml", return_value=arquivo_salvo) as mock_salvar:
+            cmd_cancelar(args)  # nao deve levantar SystemExit
+
+        mock_salvar.assert_called_once_with(
+            empresa_sul.emitente.cnpj,
+            f"{CHAVE_VALIDA}-cancelamento.xml",
+            resultado.xml,
+        )
+        out = capsys.readouterr().out
+        assert "135" in out
+        assert "RESULTADO" in out
+
+    def test_cancelar_falha_exit_1(self, empresa_sul, capsys):
+        from nfe_sync.commands.cancelamento import cmd_cancelar
+
+        resultado = _make_resultado(False, "589", "Rejeicao: Duplicidade de evento")
+        args = _make_args(empresa_sul)
+
+        with patch("nfe_sync.commands.cancelamento._carregar", return_value=(empresa_sul, {})), \
+             patch("nfe_sync.cancelamento.cancelar", return_value=resultado), \
+             patch("nfe_sync.commands.cancelamento._salvar_log_xml"), \
+             patch("nfe_sync.commands.cancelamento._salvar_xml", return_value="arquivo.xml"):
+            with pytest.raises(SystemExit) as exc:
+                cmd_cancelar(args)
+
+        assert exc.value.code == 1
+
+    def test_resultado_impresso_antes_exit(self, empresa_sul, capsys):
+        """Mesmo em caso de erro, o cStat é impresso antes do exit."""
+        from nfe_sync.commands.cancelamento import cmd_cancelar
+
+        resultado = _make_resultado(False, "589", "Rejeicao: Duplicidade de evento")
+        args = _make_args(empresa_sul)
+
+        with patch("nfe_sync.commands.cancelamento._carregar", return_value=(empresa_sul, {})), \
+             patch("nfe_sync.cancelamento.cancelar", return_value=resultado), \
+             patch("nfe_sync.commands.cancelamento._salvar_log_xml"), \
+             patch("nfe_sync.commands.cancelamento._salvar_xml", return_value="arquivo.xml"):
+            with pytest.raises(SystemExit):
+                cmd_cancelar(args)
+
+        out = capsys.readouterr().out
+        assert "589" in out
+        assert "RESULTADO" in out


### PR DESCRIPTION
## Problema
O sistema suportava emissão, consulta, manifestação e inutilização de NF-e, mas não emitia eventos de cancelamento para a SEFAZ — apenas recebia eventos via DFe.

## Solução
Adiciona o subcomando `cancelar` usando `EventoCancelarNota` (tp_evento=110111), seguindo o mesmo padrão de `manifestacao.py`.

```bash
nfe-sync cancelar EMPRESA CHAVE --protocolo 135210123456789 --justificativa "Erro de emissao"
```

## Testes
- `TestCancelarValidacao` — chave inválida, justificativa curta
- `TestCancelarSefaz` — cStat 135 (sucesso), 136 (homologado), 589 (falha)
- `TestCmdCancelar` — salva XML, exit 1 em rejeição, imprime resultado antes do exit
- `TestCancelarHomologacao` — E2E `@pytest.mark.slow` (requer certificado real)

## Verificação
```
pytest tests/test_cancelamento.py tests/test_commands_cancelamento.py -v  # 9 passed
pytest tests/ -m "not slow" -v                                            # 217 passed
```