### PR TITLE
fix: usar pynfe.utils.etree no E2E de cancelamento

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.2.81
+- fix: usar pynfe.utils.etree no E2E de cancelamento (lxml nao e dependencia direta)
+
 ## 0.2.80
 - feat: cancelamento de NF-e via SEFAZ (EventoCancelarNota)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nfe-sync"
-version = "0.2.80"
+version = "0.2.81"
 requires-python = ">=3.12"
 dependencies = ["pynfe>=0.6.5", "python-dotenv", "pydantic>=2.0", "requests", "signxml"]
 

--- a/tests/e2e/test_e2e_homolog.py
+++ b/tests/e2e/test_e2e_homolog.py
@@ -10,7 +10,7 @@ Executar com:
 import os
 import re
 import pytest
-from lxml import etree
+from pynfe.utils import etree
 from .conftest import run_nfe
 
 


### PR DESCRIPTION
## Problema
O fixture `nf_cancelada` em `test_e2e_homolog.py` importava `from lxml import etree` diretamente. `lxml` não é dependência declarada do projeto — é transitiva via pynfe — então o import pode quebrar em futuras versões.

## Solução
Substituído por `from pynfe.utils import etree`, consistente com os demais testes do projeto (`test_cancelamento.py`, etc.).

## Verificação
```
pytest tests/ -m "not slow" -q  # 217 passed
```