### PR TITLE
fix: #76 #77 — cancelar usa UF do emitente; teste de saída não duplicada

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.2.82
+- fix: #76 #77 — cancelar usa uf do emitente (nao AN); teste de saida nao duplicada
+
 ## 0.2.81
 - fix: usar pynfe.utils.etree no E2E de cancelamento (lxml nao e dependencia direta)
 

--- a/nfe_sync/cancelamento.py
+++ b/nfe_sync/cancelamento.py
@@ -29,7 +29,7 @@ def cancelar(
         cnpj=empresa.emitente.cnpj,
         chave=chave,
         data_emissao=agora_brt(),
-        uf="AN",
+        uf=empresa.uf,
         protocolo=protocolo,
         justificativa=justificativa,
         n_seq_evento=1,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nfe-sync"
-version = "0.2.81"
+version = "0.2.82"
 requires-python = ">=3.12"
 dependencies = ["pynfe>=0.6.5", "python-dotenv", "pydantic>=2.0", "requests", "signxml"]
 

--- a/tests/test_cancelamento.py
+++ b/tests/test_cancelamento.py
@@ -36,6 +36,66 @@ def _patch_pynfe(chamar_sefaz_return):
     )
 
 
+class TestCancelarUF:
+    """#76: uf deve ser a UF do emitente, não "AN" (Ambiente Nacional)."""
+
+    def test_evento_usa_uf_emitente(self, empresa_sul):
+        """EventoCancelarNota deve receber uf=empresa.uf, não uf="AN"."""
+        xml_bytes = (
+            b'<?xml version="1.0"?>'
+            b'<retEnvEvento xmlns="http://www.portalfiscal.inf.br/nfe">'
+            b'<retEvento><infEvento>'
+            b'<cStat>135</cStat><xMotivo>ok</xMotivo>'
+            b'</infEvento></retEvento></retEnvEvento>'
+        )
+        xml_el = etree.fromstring(xml_bytes)
+
+        with patch("nfe_sync.cancelamento.EventoCancelarNota") as mock_evento, \
+             patch("nfe_sync.cancelamento.SerializacaoXML"), \
+             patch("nfe_sync.cancelamento.AssinaturaA1"), \
+             patch("nfe_sync.cancelamento.chamar_sefaz", return_value=(xml_el, xml_bytes.decode())):
+            cancelar(empresa_sul, CHAVE_VALIDA, PROTOCOLO_VALIDO, JUSTIFICATIVA_VALIDA)
+
+        kwargs = mock_evento.call_args.kwargs
+        assert kwargs["uf"] == empresa_sul.uf
+        assert kwargs["uf"] != "AN"
+
+
+class TestCancelarSaida:
+    """#77: saída não deve ser duplicada."""
+
+    def test_cabecalho_aparece_uma_vez(self, empresa_sul, capsys):
+        from nfe_sync.commands.cancelamento import cmd_cancelar
+        from nfe_sync.results import ResultadoCancelamento
+        from unittest.mock import MagicMock
+
+        resultado = ResultadoCancelamento(
+            sucesso=False,
+            resultados=[{"status": "250", "motivo": "Rejeicao: UF diverge"}],
+            protocolo=None,
+            xml="<x/>",
+            xml_resposta="<x/>",
+        )
+        args = MagicMock()
+        args.empresa = empresa_sul.nome
+        args.chave = CHAVE_VALIDA
+        args.protocolo = PROTOCOLO_VALIDO
+        args.justificativa = JUSTIFICATIVA_VALIDA
+        args.homologacao = True
+        args.producao = False
+
+        with patch("nfe_sync.commands.cancelamento._carregar", return_value=(empresa_sul, {})), \
+             patch("nfe_sync.cancelamento.cancelar", return_value=resultado), \
+             patch("nfe_sync.commands.cancelamento._salvar_log_xml"), \
+             patch("nfe_sync.commands.cancelamento._salvar_xml", return_value="arquivo.xml"):
+            with pytest.raises(SystemExit):
+                cmd_cancelar(args)
+
+        out = capsys.readouterr().out
+        assert out.count("Empresa:") == 1
+        assert out.count("=== RESULTADO ===") == 1
+
+
 class TestCancelarSefaz:
     def test_cancelar_sucesso(self, empresa_sul):
         xml_bytes = (


### PR DESCRIPTION
## Problema

**#76** — `cancelamento.py` usava `uf="AN"` (Ambiente Nacional) hardcoded no `EventoCancelarNota`. Cancelamentos são eventos do **emitente** e devem ir para a SEFAZ autorizadora do estado, não para o Ambiente Nacional. Resultado: cStat=250 (UF diverge da UF autorizadora) em toda tentativa de cancelamento.

**#77** — Output duplicado suspeito. Adicionado teste de regressão que confirma que o cabeçalho e o bloco RESULTADO aparecem exatamente uma vez.

## Solução

`cancelamento.py`: `uf="AN"` → `uf=empresa.uf`

pynfe faz `.upper()` internamente antes de lookup em `CODIGOS_ESTADOS`, então a sigla em lowercase (`"sp"`, `"go"`) funciona corretamente.

## Testes adicionados

- `TestCancelarUF::test_evento_usa_uf_emitente` — verifica que `EventoCancelarNota` recebe `uf=empresa.uf` e não `"AN"`
- `TestCancelarSaida::test_cabecalho_aparece_uma_vez` — regressão para #77: `"Empresa:"` e `"=== RESULTADO ==="` aparecem exatamente uma vez no output

## Verificação
```
pytest tests/test_cancelamento.py tests/test_commands_cancelamento.py -v  # 11 passed
pytest tests/ -m "not slow" -q                                            # 219 passed
```

Closes #76
Closes #77