### PR TITLE
fix: #79 — dhEvento usa timezone local do sistema; evita cStat=577

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.2.83
+- fix: #79 — dhEvento usa timezone local do sistema (agora_local) evitando cStat=577
+
 ## 0.2.82
 - fix: #76 #77 — cancelar usa uf do emitente (nao AN); teste de saida nao duplicada
 

--- a/nfe_sync/cancelamento.py
+++ b/nfe_sync/cancelamento.py
@@ -5,7 +5,7 @@ from pynfe.processamento.assinatura import AssinaturaA1
 
 from .models import EmpresaConfig, validar_cnpj_sefaz
 from .exceptions import NfeValidationError
-from .xml_utils import extract_status_motivo, agora_brt, chamar_sefaz
+from .xml_utils import extract_status_motivo, agora_local, chamar_sefaz
 from .results import ResultadoCancelamento
 
 NS = {"ns": "http://www.portalfiscal.inf.br/nfe"}
@@ -28,7 +28,7 @@ def cancelar(
         _fonte_dados=fonte,
         cnpj=empresa.emitente.cnpj,
         chave=chave,
-        data_emissao=agora_brt(),
+        data_emissao=agora_local(),
         uf=empresa.uf,
         protocolo=protocolo,
         justificativa=justificativa,

--- a/nfe_sync/xml_utils.py
+++ b/nfe_sync/xml_utils.py
@@ -13,6 +13,19 @@ def agora_brt() -> datetime:
     """Retorna o datetime atual no fuso BRT (UTC-3), com tzinfo preservado."""
     return datetime.now(_BRT)
 
+
+def agora_local() -> datetime:
+    """Retorna o datetime atual no fuso horário LOCAL do sistema.
+
+    Necessário para eventos pynfe: SerializacaoXML.serializar_evento() usa o
+    timezone do SISTEMA (datetime.now().astimezone()) para montar o offset do
+    campo dhEvento, ignorando o tzinfo do datetime recebido. Passar um datetime
+    já convertido para o timezone local garante que o valor horário e o offset
+    sejam consistentes — evitando cStat=577 quando o servidor está em fuso
+    diferente do BRT. Issue #79.
+    """
+    return datetime.now().astimezone()
+
 # Seguro contra ataques XXE: sem resolucao de entidades externas ou DTD
 # Issue #3
 _PARSER = etree.XMLParser(resolve_entities=False, no_network=True, load_dtd=False)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nfe-sync"
-version = "0.2.82"
+version = "0.2.83"
 requires-python = ">=3.12"
 dependencies = ["pynfe>=0.6.5", "python-dotenv", "pydantic>=2.0", "requests", "signxml"]
 


### PR DESCRIPTION
## Problema

`cancelamento.py` passava `data_emissao=agora_brt()` ao `EventoCancelarNota`. O pynfe ignora o `tzinfo` do datetime recebido e usa o timezone do **sistema** para montar o offset de `dhEvento`:

```python
# pynfe/serializar_evento:
tz = datetime.now().astimezone().strftime("%z")        # offset do sistema, ex: +0100
dhEvento = evento.data_emissao.strftime("%H:%M:%S") + tz  # valor BRT + offset errado
```

Em servidor UTC+1: `00:42 BRT` + `+01:00` → SEFAZ interpreta como `23:42 UTC do dia anterior` → anterior à emissão → cStat=577.

## Solução

Adicionado `agora_local()` em `xml_utils.py` — retorna `datetime.now().astimezone()`, convertendo para o timezone local do sistema. `cancelamento.py` passa `data_emissao=agora_local()`.

| Situação | Antes | Depois |
|---|---|---|
| Servidor BRT | ✓ funciona por acaso | ✓ correto |
| Servidor UTC+1 | ✗ cStat=577 | ✓ correto |
| Servidor UTC | ✗ cStat=577 | ✓ correto |

## Testes adicionados

- `TestCancelarTimezone::test_usa_agora_local_nao_agora_brt` — verifica que `agora_local()` é chamada e que `data_emissao` recebe o valor retornado (portável: funciona em qualquer timezone)

## Verificação
```
pytest tests/test_cancelamento.py tests/test_commands_cancelamento.py -v  # 12 passed
pytest tests/ -m "not slow" -q                                            # 220 passed
```

Closes #79