### PR TITLE
refactor: #81 — validacao de endereco do emitente na API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.2.84
+- refactor: #81 — mover validacao de endereco do emitente para emissao.py
+
 ## 0.2.83
 - fix: #79 — dhEvento usa timezone local do sistema (agora_local) evitando cStat=577
 

--- a/nfe_sync/emissao.py
+++ b/nfe_sync/emissao.py
@@ -8,6 +8,7 @@ from pynfe.processamento.serializacao import SerializacaoXML
 from pynfe.processamento.assinatura import AssinaturaA1
 
 from .models import EmpresaConfig, DadosEmissao, validar_cnpj_sefaz
+from .exceptions import NfeValidationError
 from .xml_utils import to_xml_string, extract_status_motivo, criar_comunicacao, safe_fromstring, agora_brt
 from .results import ResultadoEmissao
 
@@ -17,9 +18,13 @@ NS = {"ns": "http://www.portalfiscal.inf.br/nfe"}
 
 def emitir(empresa: EmpresaConfig, serie: str, numero_nf: int, dados: DadosEmissao) -> ResultadoEmissao:
     validar_cnpj_sefaz(empresa.emitente.cnpj, empresa.nome)
-    fonte = FonteDados()
     emi = empresa.emitente
     end = emi.endereco
+    if end is None:
+        raise NfeValidationError(
+            f"[{empresa.nome}] Emitente sem endereco configurado."
+        )
+    fonte = FonteDados()
 
     emitente = PynfeEmitente(
         _fonte_dados=fonte,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nfe-sync"
-version = "0.2.83"
+version = "0.2.84"
 requires-python = ">=3.12"
 dependencies = ["pynfe>=0.6.5", "python-dotenv", "pydantic>=2.0", "requests", "signxml"]
 

--- a/tests/test_emitir.py
+++ b/tests/test_emitir.py
@@ -102,6 +102,28 @@ class TestDadosEmissao:
             DadosEmissao(destinatario=None, produtos=[], pagamentos=[])
 
 
+class TestEmitirValidacaoEndereco:
+    """#81: emitir() deve levantar NfeValidationError quando emitente.endereco é None.
+
+    Destinatario.endereco é Endereco (obrigatório no Pydantic) — não pode ser None.
+    A validação do destinatário sem endereço é lógica de montagem do CLI e fica em
+    commands/emissao.py.
+    """
+
+    def test_emitente_sem_endereco_levanta_validation_error(self, dados_emissao_padrao):
+        from nfe_sync.emissao import emitir
+        from nfe_sync.exceptions import NfeValidationError
+        from nfe_sync.models import EmpresaConfig, Certificado, Emitente
+        empresa = EmpresaConfig(
+            nome="SUL",
+            certificado=Certificado(path="/tmp/cert.pfx", senha="123456"),
+            emitente=Emitente(cnpj="99999999000191", endereco=None),
+            uf="sp", homologacao=True,
+        )
+        with pytest.raises(NfeValidationError, match="endereco"):
+            emitir(empresa, "1", 1, dados_emissao_padrao)
+
+
 class TestComplementoTruncado:
     """Issue #54: complemento truncado a 60 chars na serialização para pynfe."""
 


### PR DESCRIPTION
## Problema

A validação `emitente.endereco is None` estava apenas no layer de CLI (`commands/emissao.py`), expondo a API (`emissao.emitir()`) a `AttributeError` quando chamada diretamente sem passar pelo CLI.

## Solução

Moved the validation to `emissao.py:emitir()` — primeira linha após `validar_cnpj_sefaz()`. A função agora levanta `NfeValidationError` com mensagem clara antes de tentar acessar `end.logradouro` etc.

`Destinatario.endereco` é `Endereco` obrigatório no Pydantic — não pode ser `None`, então não precisou mover validação para o destinatário.

## Testes

`TestEmitirValidacaoEndereco::test_emitente_sem_endereco_levanta_validation_error` — verifica que `emitir()` levanta `NfeValidationError` com match `"endereco"` quando `empresa.emitente.endereco=None`.

## Verificação

```
pytest tests/test_emitir.py -v  # 9 passed
pytest tests/ -v                # 221 passed
```

Closes #81