### PR TITLE
fix: #82 — registrar cooldown para cStat=656 (Consumo Indevido)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.2.85
+- fix: #82 — registrar cooldown para cStat=656 (Consumo Indevido)
+
 ## 0.2.84
 - refactor: #81 — mover validacao de endereco do emitente para emissao.py
 

--- a/nfe_sync/consulta.py
+++ b/nfe_sync/consulta.py
@@ -256,7 +256,7 @@ def consultar_nsu(
         if ult_nsu >= max_nsu:
             break
 
-    if c_stat == "137":
+    if c_stat in ("137", "656"):
         set_cooldown(estado, cnpj, calcular_proximo_cooldown(), ambiente)
         if state_file:
             salvar_estado(state_file, estado)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nfe-sync"
-version = "0.2.84"
+version = "0.2.85"
 requires-python = ">=3.12"
 dependencies = ["pynfe>=0.6.5", "python-dotenv", "pydantic>=2.0", "requests", "signxml"]
 


### PR DESCRIPTION
## Problema

`consultar_nsu()` só registrava cooldown para `cStat=137`. Quando a SEFAZ retornava `cStat=656` (Consumo Indevido), nenhum cooldown era gravado no `.state.json`, permitindo chamadas repetidas que agravavam o bloqueio.

## Solução

`consulta.py:259`: `c_stat == "137"` → `c_stat in ("137", "656")`.

## Testes

`TestConsultarNsuCstat656`:
- `test_656_registra_cooldown` — verifica que o cooldown é gravado no estado após receber cStat=656
- `test_656_sucesso_false` — verifica `resultado.sucesso is False` e `resultado.status == "656"`

## Verificação

```
pytest tests/test_consulta.py::TestConsultarNsuCstat656 -v  # 2 passed
pytest tests/ -v                                            # 223 passed
```

Closes #82