### PR TITLE
feat: #85 — teste E2E fluxo completo emissão → consulta → manifestação → cancelamento

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.2.86
+- feat: #85 — teste E2E fluxo completo emissao-consulta-manifestacao-cancelamento
+
 ## 0.2.85
 - fix: #82 — registrar cooldown para cStat=656 (Consumo Indevido)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nfe-sync"
-version = "0.2.85"
+version = "0.2.86"
 requires-python = ">=3.12"
 dependencies = ["pynfe>=0.6.5", "python-dotenv", "pydantic>=2.0", "requests", "signxml"]
 

--- a/tests/e2e/test_fluxo_completo.py
+++ b/tests/e2e/test_fluxo_completo.py
@@ -1,0 +1,95 @@
+"""Teste E2E de fluxo completo: emissão → consulta → manifestação → cancelamento.
+
+Requer emitente e destinatário configurados:
+
+    pytest tests/e2e/test_fluxo_completo.py -v \\
+        --emitente SUL --destinatario SRNACIONAL --serie 99
+"""
+import re
+import pytest
+from .conftest import run_nfe
+
+
+@pytest.fixture(scope="class")
+def nf_fluxo(emitente, destinatario, serie):
+    """Emite uma NF-e com destinatário e retorna {"chave": ..., "protocolo": ...}.
+
+    Escopo class: emissão única compartilhada entre todos os testes da classe.
+    Falha explicitamente se --destinatario não for fornecido.
+    """
+    if destinatario is None:
+        pytest.fail("--destinatario e obrigatorio para TestFluxoCompleto")
+
+    result = run_nfe("emitir", emitente, "--serie", serie, "--destinatario", destinatario)
+    assert result.returncode == 0, f"Falha ao emitir NF-e:\n{result.stdout}\n{result.stderr}"
+
+    match_chave = re.search(r"Chave: (\d{44})", result.stdout)
+    assert match_chave, f"Chave nao encontrada na saida:\n{result.stdout}"
+
+    match_prot = re.search(r"Protocolo: (\d+)", result.stdout)
+    assert match_prot, f"Protocolo nao encontrado na saida:\n{result.stdout}"
+
+    return {"chave": match_chave.group(1), "protocolo": match_prot.group(1)}
+
+
+@pytest.mark.slow
+class TestFluxoCompleto:
+    """Fluxo E2E: emissão → consulta (emitente+dest) → manifestação → cancelamento → sincronização."""
+
+    def test_emitir(self, nf_fluxo):
+        """Etapa 1: NF-e emitida com sucesso, chave e protocolo capturados."""
+        assert len(nf_fluxo["chave"]) == 44
+        assert nf_fluxo["chave"].isdigit()
+        assert nf_fluxo["protocolo"]
+
+    def test_consultar_emitente(self, nf_fluxo, emitente):
+        """Etapa 2: EMITENTE consulta a NF-e emitida — deve estar autorizada (cStat=100)."""
+        result = run_nfe("consultar", emitente, nf_fluxo["chave"])
+        assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        assert "100" in result.stdout
+
+    def test_consultar_destinatario(self, nf_fluxo, destinatario):
+        """Etapa 3: DESTINATARIO consulta a mesma NF-e — deve estar autorizada (cStat=100)."""
+        if destinatario is None:
+            pytest.fail("--destinatario e obrigatorio para TestFluxoCompleto")
+        result = run_nfe("consultar", destinatario, nf_fluxo["chave"])
+        assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        assert "100" in result.stdout
+
+    def test_manifestar_ciencia(self, nf_fluxo, destinatario):
+        """Etapa 4: DESTINATARIO manifesta ciência da operação."""
+        if destinatario is None:
+            pytest.fail("--destinatario e obrigatorio para TestFluxoCompleto")
+        result = run_nfe("manifestar", destinatario, "ciencia", nf_fluxo["chave"])
+        assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        assert "135" in result.stdout or "136" in result.stdout
+
+    def test_cancelar(self, nf_fluxo, emitente):
+        """Etapa 5: EMITENTE cancela a NF-e."""
+        result = run_nfe(
+            "cancelar", emitente, nf_fluxo["chave"],
+            "--protocolo", nf_fluxo["protocolo"],
+            "--justificativa", "Cancelamento de NF-e de teste E2E fluxo completo",
+        )
+        assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        assert "135" in result.stdout or "136" in result.stdout
+
+    def test_consultar_cancelada(self, nf_fluxo, emitente):
+        """Etapa 6: EMITENTE confirma que a NF-e está cancelada (cStat=101)."""
+        result = run_nfe("consultar", emitente, nf_fluxo["chave"])
+        assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        assert "101" in result.stdout
+
+    def test_consultar_nsu_emitente(self, emitente):
+        """Etapa 7: EMITENTE sincroniza via distribuição DFe. Skip se rate limit (656)."""
+        result = run_nfe("consultar-nsu", emitente)
+        if "656" in result.stdout:
+            pytest.skip("SEFAZ rate limit (cStat=656) — tente novamente apos 1 hora")
+        assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+
+    def test_consultar_nsu_destinatario(self, nf_fluxo, destinatario):
+        """Etapa 8: DESTINATARIO sincroniza via distribuição DFe. Skip se rate limit (656)."""
+        result = run_nfe("consultar-nsu", destinatario)
+        if "656" in result.stdout:
+            pytest.skip("SEFAZ rate limit (cStat=656) — tente novamente apos 1 hora")
+        assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"


### PR DESCRIPTION
## Problema

Os testes E2E cobriam emissão, consulta-nsu e cancelamento de forma isolada, sem um teste que validasse o fluxo completo com emitente e destinatário em sequência.

## Solução

Novo arquivo `tests/e2e/test_fluxo_completo.py` com `TestFluxoCompleto` (8 etapas):

1. Emite NF-e com `--destinatario` — captura chave e protocolo via fixture `nf_fluxo`
2. EMITENTE consulta a NF-e → cStat=100
3. DESTINATARIO consulta a mesma NF-e → cStat=100
4. DESTINATARIO manifesta ciência → cStat=135/136
5. EMITENTE cancela → cStat=135/136
6. EMITENTE confirma cancelamento → cStat=101
7. EMITENTE consultar-nsu → skip se cStat=656 (rate limit)
8. DESTINATARIO consultar-nsu → skip se cStat=656 (rate limit)

**`--destinatario` obrigatório:** `pytest.fail()` se não fornecido (não skip silencioso).  
**Fixture `nf_fluxo` com `scope="class"`** — emissão única compartilhada entre todos os testes.

## Verificação

```bash
# Suite padrão — passa sem parâmetros
pytest tests/ -v  # 223 passed, 16 skipped

# E2E completo (requer certificados):
pytest tests/e2e/test_fluxo_completo.py -v \
    --emitente SUL --destinatario SRNACIONAL --serie 99
```

Closes #85