### PR TITLE
release: 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.0.0
+- release: versão 1.0.0 — estável com emissão, consulta, manifestação, inutilização, cancelamento e distribuição DFe
+
 ## 0.2.93
 - feat: #94 — Certificado.conteudo bytes + cert_path() para certificados em banco de dados
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nfe-sync"
-version = "0.2.93"
+version = "1.0.0"
 requires-python = ">=3.12"
 dependencies = ["pynfe>=0.6.5", "python-dotenv", "pydantic>=2.0", "requests", "signxml"]
 


### PR DESCRIPTION
## Release 1.0.0

Primeira versão estável do nfe-sync.

### Funcionalidades incluídas

| Operação | Comando |
|---|---|
| Emissão de NF-e | `nfe-sync emitir` |
| Consulta por chave | `nfe-sync consultar` |
| Distribuição DFe (todas as empresas) | `nfe-sync consultar-nsu` |
| Manifestação do destinatário | `nfe-sync manifestar` |
| Inutilização de numeração | `nfe-sync inutilizar` |
| Cancelamento de NF-e | `nfe-sync cancelar` |
| Resumos pendentes | `nfe-sync pendentes` |

### Destaques técnicos

- Certificado aceita `bytes` direto (banco de dados) via `Certificado.conteudo` + `cert_path()`
- Cooldown automático para cStat=137 e cStat=656 (Consumo Indevido)
- Validações de entrada antes de chamadas à SEFAZ
- Suite de testes completa (231 unitários + E2E com fluxo completo)
- Suporte a múltiplas empresas em todos os comandos

## Verificação

```
pytest tests/ -v  # 231 passed, 16 skipped
```